### PR TITLE
change skip conversion to warning

### DIFF
--- a/ebookmaker/writers/PDFWriter.py
+++ b/ebookmaker/writers/PDFWriter.py
@@ -37,7 +37,7 @@ class Writer (writers.BaseWriter):
         parser = ParserFactory.ParserFactory.create (inputfilename)
 
         if not hasattr (parser, 'rst2xetex'):
-            error ('PDFWriter can only work on a RSTParser.')
+            warning ('Skipping PDF Output because input mediatype is %s' % parser.mediatype())
             raise SkipOutputFormat
 
         # Brain-dead xetex doesn't understand unix pipes


### PR DESCRIPTION
html >> pdf conversion fails by design, not by error, so change the error message to a more helpul warning