### PR TITLE
Fix rst

### DIFF
--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -158,7 +158,7 @@ def get_dc (url):
 
     dc.project_gutenberg_id = options.ebook or dc.project_gutenberg_id
     if dc.project_gutenberg_id:
-        dc.opf_identifier = ('http://www.gutenberg.org/ebooks/%d' % dc.project_gutenberg_id)
+        dc.opf_identifier = ('https://www.gutenberg.org/ebooks/%d' % dc.project_gutenberg_id)
     else:
         dc.opf_identifier = ('urn:mybooks:%s' %
                              hashlib.md5 (dc.source.encode ('utf-8')).hexdigest ())

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -125,7 +125,7 @@ class ParserFactory (object):
             url,
             stream = True,
             headers = {
-                'User-Agent': "EbookMaker/%s (+http://pypi.python.org/ebookmaker)" % VERSION
+                'User-Agent': "EbookMaker/%s (+https://pypi.python.org/ebookmaker)" % VERSION
             },
             proxies = options.config.PROXIES
         )

--- a/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
+++ b/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
@@ -105,7 +105,7 @@ class VariablesTransform (docutils.transforms.Transform):
                 sub (variable, [ nodes.inline ('', getone ('PG.Credits', '')) ])
 
             elif name == 'pg.bibrec-url':
-                url = 'http://www.gutenberg.org/ebooks/%s' % getone ('PG.Id', '999999')
+                url = 'https://www.gutenberg.org/ebooks/%s' % getone ('PG.Id', '999999')
                 sub (variable, [ nodes.reference ('', '', nodes.inline ('', url), refuri = url) ])
 
             elif name in ('pg.copyrighted-header', 'pg.copyrighted-footer'):

--- a/ebookmaker/mydocutils/parsers/__init__.py
+++ b/ebookmaker/mydocutils/parsers/__init__.py
@@ -621,31 +621,36 @@ class Role:
 class Inliner (states.Inliner):
     """ Inliner that recognizes [pg n], [ln n], and [var x]. """
 
-    re_pageno = re.compile (states.Inliner.start_string_prefix +
-                            r"(\[pg!?\s*(?P<pageno>[-ivxlc\d]+)(?:\s+(?P<imgoff>[\d]+))?\])" +
-                            states.Inliner.end_string_suffix + r'\s*', re.IGNORECASE)
-    re_pageref = re.compile (states.Inliner.start_string_prefix +
-                            r"(\[pg\s*(?P<pageno>[-ivxlc\d]+)\]_)" +
-                            states.Inliner.end_string_suffix, re.IGNORECASE)
-    re_lineno = re.compile (states.Inliner.start_string_prefix +
-                            r"(\[ln!?\s*(?P<lineno>[\d]+)\])" +
-                            states.Inliner.end_string_suffix + r'\s*', re.IGNORECASE)
-    re_lineref = re.compile (states.Inliner.start_string_prefix +
-                            r"(\[ln\s*(?P<lineno>[\d]+)\]_)" +
-                            states.Inliner.end_string_suffix, re.IGNORECASE)
-    re_variable = re.compile (states.Inliner.start_string_prefix +
-                            r"(\[var\s+(?P<name>[-_\w\d]+)\])" +
-                            states.Inliner.end_string_suffix + r'\s*', re.IGNORECASE)
-    # re_newline = re.compile (states.Inliner.start_string_prefix +
-    #                         r"\[br\]" +
-    #                         states.Inliner.end_string_suffix)
-
-    def __init__ (self):
-        states.Inliner.__init__ (self)
-
 
     def init_customizations (self, settings):
         """ Setting-based customizations; run when parsing begins. """
+        super().init_customizations (settings)
+
+        self.re_pageno = re.compile (
+            self.start_string_prefix +
+            r"(\[pg!?\s*(?P<pageno>[-ivxlc\d]+)(?:\s+(?P<imgoff>[\d]+))?\])" +
+            self.end_string_suffix + r'\s*', re.IGNORECASE
+        )
+        self.re_pageref = re.compile (
+            self.start_string_prefix +
+            r"(\[pg\s*(?P<pageno>[-ivxlc\d]+)\]_)" +
+            self.end_string_suffix, re.IGNORECASE
+        )
+        self.re_lineno = re.compile (
+            self.start_string_prefix +
+            r"(\[ln!?\s*(?P<lineno>[\d]+)\])" +
+            self.end_string_suffix + r'\s*', re.IGNORECASE
+        )
+        self.re_lineref = re.compile (
+            self.start_string_prefix +
+            r"(\[ln\s*(?P<lineno>[\d]+)\]_)" +
+            self.end_string_suffix, re.IGNORECASE
+        )
+        self.re_variable = re.compile (
+            self.start_string_prefix +
+            r"(\[var\s+(?P<name>[-_\w\d]+)\])" +
+            self.end_string_suffix + r'\s*', re.IGNORECASE
+        )
 
         # self.implicit_dispatch.append ((self.re_newline, self.newline))
         self.implicit_dispatch.append ((self.re_variable, self.variable))
@@ -655,7 +660,6 @@ class Inliner (states.Inliner):
             self.implicit_dispatch.append ((self.re_pageref, self.pageno_reference))
             self.implicit_dispatch.append ((self.re_lineno,  self.lineno_target))
             self.implicit_dispatch.append ((self.re_lineref, self.lineno_reference))
-
 
     def variable (self, match, dummy_lineno):
         """ Makes `[var x]` into implicit markup for a variable named x. """
@@ -733,6 +737,13 @@ class Inliner (states.Inliner):
             return [reference]
         else:
             raise states.MarkupMismatch
+
+# copy states.Inliner properties to Inliner so that init_customizations method works
+# this is needed because init_customizations depends on locals(), which seems like a bad practice
+#
+for prop, val in states.Inliner.__dict__.items():
+    if not prop.startswith('_'):
+        setattr(Inliner, prop, val)
 
 
 class Body (states.Body):

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup (
     long_description = open ('README').read (),
     license = "GPL v3",
     keywords = "ebook epub kindle pdf rst reST reStructuredText project gutenberg format conversion",
-    url = "http://pypi.python.org/pypi/ebookmaker/",
+    url = "https://pypi.python.org/pypi/ebookmaker/",
 
     classifiers = [
         "Topic :: Text Processing",


### PR DESCRIPTION
because of changes in the way Inliner works,  init_customizations must call super.

Unfortunately init_customizations in DocUtils calls locals() to get Inliner members in a dict which cause it to fail when called from a subclass. So, to make it work, we must bring super class members to local symbol table. I'd file a PR if docutils was on github.