### PR TITLE
Refix rst

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.7.0 September 20, 2019
+
+- config files can now be used to provide defaults for most command line arguments.
+
 0.6.4 September 16, 2019
 
 - added updates so that gutenberg canonical url is always https

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.6.4 September 16, 2019
+
+- added updates so that gutenberg canonical url is always https
+- updated libgutenberg requirement
+
 0.6.3 September 12, 2019
 
 - fixed parsing of rst files in MyDocUtils

--- a/Pipfile
+++ b/Pipfile
@@ -8,4 +8,4 @@ name = "pypi"
 [packages]
 e1839a8 = {path = ".",editable = true}
 ebookmaker = {editable = true,path = "."}
-libgutenberg = "==0.3.2"
+libgutenberg = "==0.4.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a13b499b7077e1f471a3dec0afa3ab4f737e65bf91c3bcd7f63ae58391a554f8"
+            "sha256": "9184f82d29508b8295f058e90411d6a5d7057f328d17e543362dbeafaf417944"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -29,10 +29,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.9.11"
         },
         "cffi": {
             "hashes": [
@@ -76,17 +76,17 @@
         },
         "cheroot": {
             "hashes": [
-                "sha256:1593fa2a42b18744ac485aadf5fec4a29ebfee00ba3937a2269b8ffc94447879",
-                "sha256:f6a85e005adb5bc5f3a92b998ff0e48795d4d98a0fbb7edde47a7513d4100601"
+                "sha256:427e7e3ce51ad5a6e5cf953252b5782d5dfbeb544c09910634971bc06df6621b",
+                "sha256:74d733c55178812253d855990f7ad7b31ab4ee8dab80e4803bd5e52299c50395"
             ],
-            "version": "==6.5.5"
+            "version": "==6.5.8"
         },
         "cherrypy": {
             "hashes": [
-                "sha256:3c7b27fd1af4964434d821cd139b8d05c8f7fe4f37ae146fddb3f861d80a1da7",
-                "sha256:6585c19b5e4faffa3613b5bf02c6a27dcc4c69a30d302aba819639a2af6fa48b"
+                "sha256:16fc226a280cd772ede7c309d3964002196784ac6615d8bface52be12ff51230",
+                "sha256:488ea5e639885c75330686c1d7d3dfbd002f784c027a3fe5b374b41926b8cba3"
             ],
-            "version": "==18.1.1"
+            "version": "==18.2.0"
         },
         "cssutils": {
             "hashes": [
@@ -97,11 +97,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "version": "==0.14"
+            "version": "==0.15.2"
         },
         "e1839a8": {
             "editable": true,
@@ -130,86 +130,82 @@
                 "covers"
             ],
             "hashes": [
-                "sha256:498cdcb2d4e1c4749bba9bd86fc08819637741c8093dc98a39d9f14b645a379c"
+                "sha256:22a30f6cbe3bbefd1a51159b4de78bced1b8f18c690f41a3825139ca9ba1f7bb"
             ],
             "index": "pypi",
-            "version": "==0.3.2"
+            "version": "==0.4.0"
         },
         "lxml": {
             "hashes": [
-                "sha256:03984196d00670b2ab14ae0ea83d5cc0cfa4f5a42558afa9ab5fa745995328f5",
-                "sha256:0815b0c9f897468de6a386dc15917a0becf48cc92425613aa8bbfc7f0f82951f",
-                "sha256:175f3825f075cf02d15099eb52658457cf0ff103dcf11512b5d2583e1d40f58b",
-                "sha256:30e14c62d88d1e01a26936ecd1c6e784d4afc9aa002bba4321c5897937112616",
-                "sha256:3210da6f36cf4b835ff1be853962b22cc354d506f493b67a4303c88bbb40d57b",
-                "sha256:40f60819fbd5bad6e191ba1329bfafa09ab7f3f174b3d034d413ef5266963294",
-                "sha256:43b26a865a61549919f8a42e094dfdb62847113cf776d84bd6b60e4e3fc20ea3",
-                "sha256:4a03dd682f8e35a10234904e0b9508d705ff98cf962c5851ed052e9340df3d90",
-                "sha256:62f382cddf3d2e52cf266e161aa522d54fd624b8cc567bc18f573d9d50d40e8e",
-                "sha256:7b98f0325be8450da70aa4a796c4f06852949fe031878b4aa1d6c417a412f314",
-                "sha256:846a0739e595871041385d86d12af4b6999f921359b38affb99cdd6b54219a8f",
-                "sha256:a3080470559938a09a5d0ec558c005282e99ac77bf8211fb7b9a5c66390acd8d",
-                "sha256:ad841b78a476623955da270ab8d207c3c694aa5eba71f4792f65926dc46c6ee8",
-                "sha256:afdd75d9735e44c639ffd6258ce04a2de3b208f148072c02478162d0944d9da3",
-                "sha256:b4fbf9b552faff54742bcd0791ab1da5863363fb19047e68f6592be1ac2dab33",
-                "sha256:b90c4e32d6ec089d3fa3518436bdf5ce4d902a0787dbd9bb09f37afe8b994317",
-                "sha256:b91cfe4438c741aeff662d413fd2808ac901cc6229c838236840d11de4586d63",
-                "sha256:bdb0593a42070b0a5f138b79b872289ee73c8e25b3f0bea6564e795b55b6bcdd",
-                "sha256:c4e4bca2bb68ce22320297dfa1a7bf070a5b20bcbaec4ee023f83d2f6e76496f",
-                "sha256:cec4ab14af9eae8501be3266ff50c3c2aecc017ba1e86c160209bb4f0423df6a",
-                "sha256:e83b4b2bf029f5104bc1227dbb7bf5ace6fd8fabaebffcd4f8106fafc69fc45f",
-                "sha256:e995b3734a46d41ae60b6097f7c51ba9958648c6d1e0935b7e0ee446ee4abe22",
-                "sha256:f679d93dec7f7210575c85379a31322df4c46496f184ef650d3aba1484b38a2d",
-                "sha256:fd213bb5166e46974f113c8228daaef1732abc47cb561ce9c4c8eaed4bd3b09b",
-                "sha256:fdcb57b906dbc1f80666e6290e794ab8fb959a2e17aa5aee1758a85d1da4533f",
-                "sha256:ff424b01d090ffe1947ec7432b07f536912e0300458f9a7f48ea217dd8362b86"
+                "sha256:02ca7bf899da57084041bb0f6095333e4d239948ad3169443f454add9f4e9cb4",
+                "sha256:096b82c5e0ea27ce9138bcbb205313343ee66a6e132f25c5ed67e2c8d960a1bc",
+                "sha256:0a920ff98cf1aac310470c644bc23b326402d3ef667ddafecb024e1713d485f1",
+                "sha256:17cae1730a782858a6e2758fd20dd0ef7567916c47757b694a06ffafdec20046",
+                "sha256:17e3950add54c882e032527795c625929613adbd2ce5162b94667334458b5a36",
+                "sha256:1f4f214337f6ee5825bf90a65d04d70aab05526c08191ab888cb5149501923c5",
+                "sha256:2e8f77db25b0a96af679e64ff9bf9dddb27d379c9900c3272f3041c4d1327c9d",
+                "sha256:4dffd405390a45ecb95ab5ab1c1b847553c18b0ef8ed01e10c1c8b1a76452916",
+                "sha256:6b899931a5648862c7b88c795eddff7588fb585e81cecce20f8d9da16eff96e0",
+                "sha256:726c17f3e0d7a7200718c9a890ccfeab391c9133e363a577a44717c85c71db27",
+                "sha256:760c12276fee05c36f95f8040180abc7fbebb9e5011447a97cdc289b5d6ab6fc",
+                "sha256:796685d3969815a633827c818863ee199440696b0961e200b011d79b9394bbe7",
+                "sha256:891fe897b49abb7db470c55664b198b1095e4943b9f82b7dcab317a19116cd38",
+                "sha256:a471628e20f03dcdfde00770eeaf9c77811f0c331c8805219ca7b87ac17576c5",
+                "sha256:a63b4fd3e2cabdcc9d918ed280bdde3e8e9641e04f3c59a2a3109644a07b9832",
+                "sha256:b0b84408d4eabc6de9dd1e1e0bc63e7731e890c0b378a62443e5741cfd0ae90a",
+                "sha256:be78485e5d5f3684e875dab60f40cddace2f5b2a8f7fede412358ab3214c3a6f",
+                "sha256:c27eaed872185f047bb7f7da2d21a7d8913457678c9a100a50db6da890bc28b9",
+                "sha256:c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692",
+                "sha256:d11874b3c33ee441059464711cd365b89fa1a9cf19ae75b0c189b01fbf735b84",
+                "sha256:e9c028b5897901361d81a4718d1db217b716424a0283afe9d6735fe0caf70f79",
+                "sha256:fe489d486cd00b739be826e8c1be188ddb74c7a1ca784d93d06fda882a6a1681"
             ],
-            "version": "==4.3.3"
+            "version": "==4.4.1"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
-            "version": "==7.0.0"
+            "version": "==7.2.0"
         },
         "pillow": {
             "hashes": [
-                "sha256:15c056bfa284c30a7f265a41ac4cbbc93bdbfc0dfe0613b9cb8a8581b51a9e55",
-                "sha256:1a4e06ba4f74494ea0c58c24de2bb752818e9d504474ec95b0aa94f6b0a7e479",
-                "sha256:1c3c707c76be43c9e99cb7e3d5f1bee1c8e5be8b8a2a5eeee665efbf8ddde91a",
-                "sha256:1fd0b290203e3b0882d9605d807b03c0f47e3440f97824586c173eca0aadd99d",
-                "sha256:24114e4a6e1870c5a24b1da8f60d0ba77a0b4027907860188ea82bd3508c80eb",
-                "sha256:258d886a49b6b058cd7abb0ab4b2b85ce78669a857398e83e8b8e28b317b5abb",
-                "sha256:33c79b6dd6bc7f65079ab9ca5bebffb5f5d1141c689c9c6a7855776d1b09b7e8",
-                "sha256:367385fc797b2c31564c427430c7a8630db1a00bd040555dfc1d5c52e39fcd72",
-                "sha256:3c1884ff078fb8bf5f63d7d86921838b82ed4a7d0c027add773c2f38b3168754",
-                "sha256:44e5240e8f4f8861d748f2a58b3f04daadab5e22bfec896bf5434745f788f33f",
-                "sha256:46aa988e15f3ea72dddd81afe3839437b755fffddb5e173886f11460be909dce",
-                "sha256:74d90d499c9c736d52dd6d9b7221af5665b9c04f1767e35f5dd8694324bd4601",
-                "sha256:809c0a2ce9032cbcd7b5313f71af4bdc5c8c771cb86eb7559afd954cab82ebb5",
-                "sha256:85d1ef2cdafd5507c4221d201aaf62fc9276f8b0f71bd3933363e62a33abc734",
-                "sha256:8c3889c7681af77ecfa4431cd42a2885d093ecb811e81fbe5e203abc07e0995b",
-                "sha256:9218d81b9fca98d2c47d35d688a0cea0c42fd473159dfd5612dcb0483c63e40b",
-                "sha256:9aa4f3827992288edd37c9df345783a69ef58bd20cc02e64b36e44bcd157bbf1",
-                "sha256:9d80f44137a70b6f84c750d11019a3419f409c944526a95219bea0ac31f4dd91",
-                "sha256:b7ebd36128a2fe93991293f997e44be9286503c7530ace6a55b938b20be288d8",
-                "sha256:c4c78e2c71c257c136cdd43869fd3d5e34fc2162dc22e4a5406b0ebe86958239",
-                "sha256:c6a842537f887be1fe115d8abb5daa9bc8cc124e455ff995830cc785624a97af",
-                "sha256:cf0a2e040fdf5a6d95f4c286c6ef1df6b36c218b528c8a9158ec2452a804b9b8",
-                "sha256:cfd28aad6fc61f7a5d4ee556a997dc6e5555d9381d1390c00ecaf984d57e4232",
-                "sha256:dca5660e25932771460d4688ccbb515677caaf8595f3f3240ec16c117deff89a",
-                "sha256:de7aedc85918c2f887886442e50f52c1b93545606317956d65f342bd81cb4fc3",
-                "sha256:e6c0bbf8e277b74196e3140c35f9a1ae3eafd818f7f2d3a15819c49135d6c062"
+                "sha256:0804f77cb1e9b6dbd37601cee11283bba39a8d44b9ddb053400c58e0c0d7d9de",
+                "sha256:0ab7c5b5d04691bcbd570658667dd1e21ca311c62dcfd315ad2255b1cd37f64f",
+                "sha256:0b3e6cf3ea1f8cecd625f1420b931c83ce74f00c29a0ff1ce4385f99900ac7c4",
+                "sha256:365c06a45712cd723ec16fa4ceb32ce46ad201eb7bbf6d3c16b063c72b61a3ed",
+                "sha256:38301fbc0af865baa4752ddae1bb3cbb24b3d8f221bf2850aad96b243306fa03",
+                "sha256:3aef1af1a91798536bbab35d70d35750bd2884f0832c88aeb2499aa2d1ed4992",
+                "sha256:3fe0ab49537d9330c9bba7f16a5f8b02da615b5c809cdf7124f356a0f182eccd",
+                "sha256:45a619d5c1915957449264c81c008934452e3fd3604e36809212300b2a4dab68",
+                "sha256:49f90f147883a0c3778fd29d3eb169d56416f25758d0f66775db9184debc8010",
+                "sha256:571b5a758baf1cb6a04233fb23d6cf1ca60b31f9f641b1700bfaab1194020555",
+                "sha256:5ac381e8b1259925287ccc5a87d9cf6322a2dc88ae28a97fe3e196385288413f",
+                "sha256:6153db744a743c0c8c91b8e3b9d40e0b13a5d31dbf8a12748c6d9bfd3ddc01ad",
+                "sha256:6fd63afd14a16f5d6b408f623cc2142917a1f92855f0df997e09a49f0341be8a",
+                "sha256:70acbcaba2a638923c2d337e0edea210505708d7859b87c2bd81e8f9902ae826",
+                "sha256:70b1594d56ed32d56ed21a7fbb2a5c6fd7446cdb7b21e749c9791eac3a64d9e4",
+                "sha256:76638865c83b1bb33bcac2a61ce4d13c17dba2204969dedb9ab60ef62bede686",
+                "sha256:7b2ec162c87fc496aa568258ac88631a2ce0acfe681a9af40842fc55deaedc99",
+                "sha256:7cee2cef07c8d76894ebefc54e4bb707dfc7f258ad155bd61d87f6cd487a70ff",
+                "sha256:7d16d4498f8b374fc625c4037742fbdd7f9ac383fd50b06f4df00c81ef60e829",
+                "sha256:b50bc1780681b127e28f0075dfb81d6135c3a293e0c1d0211133c75e2179b6c0",
+                "sha256:bd0582f831ad5bcad6ca001deba4568573a4675437db17c4031939156ff339fa",
+                "sha256:cfd40d8a4b59f7567620410f966bb1f32dc555b2b19f82a91b147fac296f645c",
+                "sha256:e3ae410089de680e8f84c68b755b42bc42c0ceb8c03dbea88a5099747091d38e",
+                "sha256:e9046e559c299b395b39ac7dbf16005308821c2f24a63cae2ab173bd6aa11616",
+                "sha256:ef6be704ae2bc8ad0ebc5cb850ee9139493b0fc4e81abcc240fb392a63ebc808",
+                "sha256:f8dc19d92896558f9c4317ee365729ead9d7bbcf2052a9a19a3ef17abbb8ac5b"
             ],
-            "version": "==6.0.0"
+            "version": "==6.1.0"
         },
         "portend": {
             "hashes": [
-                "sha256:507e1f76eb6deec0cc15045d1140a07874f44d02eec021e8fd383557d99fe93d",
-                "sha256:853d69e61d86aa1bc7a4976cb2f67efe1c92d3b41c47a5e6b8771d3c51b5bfd3"
+                "sha256:19dc27bfb3c72471bd30a235a4d5fbefef8a7e31cab367744b5d87a205e7bfd9",
+                "sha256:d2dca12e585ce29fc357b31ce424a27c16e2d485029252bbf8ddcc9696207976"
             ],
-            "version": "==2.4"
+            "version": "==2.5"
         },
         "pycparser": {
             "hashes": [
@@ -219,17 +215,17 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
-                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
+                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
             ],
-            "version": "==2019.1"
+            "version": "==2019.2"
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "roman": {
             "hashes": [
@@ -254,16 +250,17 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.3"
         },
         "zc.lockfile": {
             "hashes": [
-                "sha256:95a8e3846937ab2991b61703d6e0251d5abb9604e18412e2714e1b90db173253"
+                "sha256:307ad78227e48be260e64896ec8886edc7eae22d8ec53e4d528ab5537a83203b",
+                "sha256:cc33599b549f0c8a248cb72f3bf32d77712de1ff7ee8814312eb6456b42c015f"
             ],
-            "version": "==1.4"
+            "version": "==2.0"
         }
     },
     "develop": {}

--- a/ebookmaker.conf
+++ b/ebookmaker.conf
@@ -1,4 +1,32 @@
-[PATHS]
+# copy this file to /etc/ebookmaker.conf to reset default command line arguments 
+# or config paths 
+# copy this file to ~/.ebookmaker to override settings in /etc/ebookmaker.conf
 
-#MOBIGEN = /Applications/KindleGen_Mac_i386_v2_9/kindlegen
-#
+[DEFAULT_ARGS]
+# types: all [list of output types]
+# max_depth: 1
+# strip_links: False
+# include_urls: [list of urls]
+# exclude_urls: [list]
+# include_mediatypes: [list of mediatypes]
+# exclude_mediatypes: [list of mediatypes]
+# input_mediatype: None
+# mediatype_from_extension: False
+# rewrite: [url]>[rewritten url]
+# title: None
+# author: None
+# ebook: 0
+# outputdir: ./
+# outputfile: [title].epub
+# validate: False
+# section_tags: [list of classes]
+# packager: None ['ww', 'gzip']
+# cover: None [path]
+# generate_cover: False
+
+[PATHS]
+# proxies: None
+# xelatex: 'xelatex'
+# mobigen: 'kindlegen'
+# groff: 'groff'
+# rhyming_dict: None

--- a/ebookmaker/CommonCode.py
+++ b/ebookmaker/CommonCode.py
@@ -76,12 +76,19 @@ def add_common_options (ap, user_config_file):
         default  = user_config_file,
         help     = "read config file (default: %(default)s)")
 
+def set_arg_defaults(ap, config_file):
+    # get default command-line args
+    cp = configparser.ConfigParser ()
+    cp.read (config_file)
+    if cp.has_section('default_args'):
+        ap.set_defaults(**dict(cp.items('default_args')))
 
 def parse_config_and_args (ap, sys_config, defaults = None):
 
+    # put command-line args into options
     options.update(vars(ap.parse_args ()))
 
-    cp = configparser.ConfigParser (defaults)
+    cp = configparser.ConfigParser ()
     cp.read ((sys_config, options.config_file))
 
     options.config = Struct ()

--- a/ebookmaker/CommonCode.py
+++ b/ebookmaker/CommonCode.py
@@ -80,8 +80,8 @@ def set_arg_defaults(ap, config_file):
     # get default command-line args
     cp = configparser.ConfigParser ()
     cp.read (config_file)
-    if cp.has_section('default_args'):
-        ap.set_defaults(**dict(cp.items('default_args')))
+    if cp.has_section('DEFAULT_ARGS'):
+        ap.set_defaults(**dict(cp.items('DEFAULT_ARGS')))
 
 def parse_config_and_args (ap, sys_config, defaults = None):
 

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -187,7 +187,7 @@ def get_dc (url):
 
     dc.project_gutenberg_id = options.ebook or dc.project_gutenberg_id
     if dc.project_gutenberg_id:
-        dc.opf_identifier = ('http://www.gutenberg.org/ebooks/%d' % dc.project_gutenberg_id)
+        dc.opf_identifier = ('%sebooks/%d' % (gg.PG_URL, dc.project_gutenberg_id))
     else:
         dc.opf_identifier = ('urn:mybooks:%s' %
                              hashlib.md5 (dc.source.encode ('utf-8')).hexdigest ())

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -43,6 +43,8 @@ from ebookmaker.Version import VERSION
 
 options = Options()
 
+# store paths for system utilities in CONFIG_FILES[0]
+# store default command line args in [default_args] section of CONFIG_FILES[1]
 CONFIG_FILES = ['/etc/ebookmaker.conf', os.path.expanduser ('~/.ebookmaker')]
 
 DEPENDENCIES = collections.OrderedDict ((
@@ -464,6 +466,7 @@ def config ():
     ap = argparse.ArgumentParser (prog = 'EbookMaker')
     CommonCode.add_common_options (ap, CONFIG_FILES[1])
     add_local_options (ap)
+    CommonCode.set_arg_defaults (ap, CONFIG_FILES[1])
 
     global options 
     options.update(vars(CommonCode.parse_config_and_args (

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.6.4'
+VERSION = '0.7.0'
 GENERATOR = 'Ebookmaker %s by Marcello Parathoner and Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.6.3'
+VERSION = '0.6.4'
 GENERATOR = 'Ebookmaker %s by Marcello Parathoner and Project Gutenberg'

--- a/ebookmaker/mydocutils/gutenberg/parsers/pg-footer.rst
+++ b/ebookmaker/mydocutils/gutenberg/parsers/pg-footer.rst
@@ -62,7 +62,7 @@ distribution of electronic works, by using or distributing this work
 (or any other work associated in any way with the phrase “Project
 Gutenberg”), you agree to comply with all the terms of the Full
 Project Gutenberg™ License available with this file or online at
-http://www.gutenberg.org/license.
+https://www.gutenberg.org/license.
 
 
 Section 1. General Terms of Use & Redistributing Project Gutenberg™ electronic works
@@ -131,7 +131,7 @@ performed, viewed, copied or distributed:
   and most other parts of the world at no cost and with almost no
   restrictions whatsoever. You may copy it, give it away or re-use it
   under the terms of the Project Gutenberg License included with this
-  eBook or online at http://www.gutenberg.org .  If you are not
+  eBook or online at https://www.gutenberg.org .  If you are not
   located in the United States, you'll have to check the laws of the
   country where you are located before using this ebook.
 
@@ -171,7 +171,7 @@ any word processing or hypertext form. However, if you provide access
 to or distribute copies of a Project Gutenberg™ work in a format other
 than “Plain Vanilla ASCII” or other format used in the official
 version posted on the official Project Gutenberg™ web site
-(http://www.gutenberg.org), you must, at no additional cost, fee or
+(https://www.gutenberg.org), you must, at no additional cost, fee or
 expense to the user, provide a copy, a means of exporting a copy, or a
 means of obtaining a copy upon request, of the work in its original
 “Plain Vanilla ASCII” or other form. Any alternate format must include
@@ -318,7 +318,7 @@ The Project Gutenberg Literary Archive Foundation is a non profit
 state of Mississippi and granted tax exempt status by the Internal
 Revenue Service. The Foundation's EIN or federal tax identification
 number is 64-6221541. Its 501(c)(3) letter is posted at
-http://www.gutenberg.org/fundraising/pglaf . Contributions to the
+https://www.gutenberg.org/fundraising/pglaf . Contributions to the
 Project Gutenberg Literary Archive Foundation are tax deductible to
 the full extent permitted by U.S.  federal laws and your state's laws.
 
@@ -355,7 +355,7 @@ considerable effort, much paperwork and many fees to meet and keep up
 with these requirements. We do not solicit donations in locations
 where we have not received written confirmation of compliance. To SEND
 DONATIONS or determine the status of compliance for any particular
-state visit http://www.gutenberg.org/fundraising/donate
+state visit https://www.gutenberg.org/fundraising/donate
 
 While we cannot and do not solicit contributions from states where we
 have not met the solicitation requirements, we know of no prohibition
@@ -369,7 +369,7 @@ outside the United States. U.S. laws alone swamp our small staff.
 Please check the Project Gutenberg Web pages for current donation
 methods and addresses. Donations are accepted in a number of other
 ways including checks, online payments and credit card donations. To
-donate, please visit: http://www.gutenberg.org/fundraising/donate
+donate, please visit: https://www.gutenberg.org/fundraising/donate
 
 
 Section 5. General Information About Project Gutenberg™ electronic works.
@@ -399,7 +399,7 @@ eBooks receiving new filenames and etext numbers.
 Most people start at our Web site which has the main PG search
 facility:
 
-  http://www.gutenberg.org
+  https://www.gutenberg.org
 
 This Web site includes information about Project Gutenberg™, including
 how to make donations to the Project Gutenberg Literary Archive

--- a/ebookmaker/mydocutils/gutenberg/parsers/pg-header.rst
+++ b/ebookmaker/mydocutils/gutenberg/parsers/pg-header.rst
@@ -13,7 +13,7 @@
    and most other parts of the world at no cost and with almost no
    restrictions whatsoever. You may copy it, give it away or re-use it
    under the terms of the `Project Gutenberg License`_ included with
-   this ebook or online at http://www.gutenberg.org/license. If you
+   this ebook or online at https://www.gutenberg.org/license. If you
    are not located in the United States, you'll have to check the laws
    of the country where you are located before using this ebook.
 

--- a/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
+++ b/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
@@ -24,6 +24,7 @@ import docutils.transforms.parts
 
 from libgutenberg.Logger import error, warning, info, debug
 from libgutenberg.DublinCore import DublinCore
+from libgutenberg.GutenbergGlobals import PG_URL
 from ebookmaker.mydocutils import nodes as mynodes
 
 # pylint: disable=W0142
@@ -105,7 +106,7 @@ class VariablesTransform (docutils.transforms.Transform):
                 sub (variable, [ nodes.inline ('', getone ('PG.Credits', '')) ])
 
             elif name == 'pg.bibrec-url':
-                url = 'http://www.gutenberg.org/ebooks/%s' % getone ('PG.Id', '999999')
+                url =  '%sebooks/%s' % (PG_URL, getone ('PG.Id', '999999')
                 sub (variable, [ nodes.reference ('', '', nodes.inline ('', url), refuri = url) ])
 
             elif name in ('pg.copyrighted-header', 'pg.copyrighted-footer'):

--- a/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
+++ b/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
@@ -106,7 +106,7 @@ class VariablesTransform (docutils.transforms.Transform):
                 sub (variable, [ nodes.inline ('', getone ('PG.Credits', '')) ])
 
             elif name == 'pg.bibrec-url':
-                url =  '%sebooks/%s' % (PG_URL, getone ('PG.Id', '999999')
+                url =  '%sebooks/%s' % (PG_URL, getone ('PG.Id', '999999'))
                 sub (variable, [ nodes.reference ('', '', nodes.inline ('', url), refuri = url) ])
 
             elif name in ('pg.copyrighted-header', 'pg.copyrighted-footer'):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.6.3'
+VERSION = '0.6.4'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup (
         'roman',
         'requests',
         'six>=1.4.1',
-        'libgutenberg[covers]>=0.3.2',
+        'libgutenberg[covers]>=0.4.0',
     ],
     
     package_data = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.6.4'
+VERSION = '0.7.0'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
- updated rst footer to use https links
- updated opf identifier to use PG_URL from GutenbergGlobals
- config files can now be used to provide defaults for most command line arguments.
- added updates so that gutenberg canonical url is always https
- updated libgutenberg requirement