### PR TITLE
fix error on small cover candidates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+0.7.7 December 19, 2019
+
+- fixed bugs in ParserFactory that raised exceptions for parsers built from package-supplied
+  resources
+- fixed bug that raised exceptions when a cover was rejected for being too small
+
 0.7.6 December 2, 2019
 - disabled html to txt conversion because no conversion was being done
 - changed a truth eval of an etree element to silence deprecation warnings

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -195,10 +195,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2",
-                "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==8.0.0"
+            "version": "==8.0.2"
         },
         "pillow": {
             "hashes": [

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -128,8 +128,9 @@ def elect_coverpage (spider, url):
                 dimen = p.get_image_dimen ()
                 if (dimen[0] * dimen[1]) < COVERPAGE_MIN_AREA:
                     p.attribs.rel.remove ('coverpage')
+                    p_url = p.url if hasattr (p, 'url') else ''
                     warning ("removed coverpage candidate %s because too small (%d x %d)" %
-                             (p.url, dimen[0], dimen[1]))
+                             (p_url, dimen[0], dimen[1]))
                     continue
             coverpage_found = True
     if spider.parsers and not coverpage_found and options.generate_cover :

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -17,7 +17,7 @@ import os.path
 from six.moves import urllib
 import six
 
-from pkg_resources import resource_listdir # pylint: disable=E0611
+from pkg_resources import resource_listdir, resource_stream # pylint: disable=E0611
 import requests
 
 from libgutenberg.Logger import debug
@@ -162,15 +162,15 @@ class ParserFactory (object):
 
         # resource://python.package/filename.ext
 
-        o = urllib.parse.urlsplit (url)
-        package = o.host
+        o = urllib.parse.urlsplit (orig_url)
+        package = o.hostname
         filename = o.path
         fp = resource_stream (package, filename)
         attribs.orig_mediatype = attribs.HeaderElement (MediaTypes.guess_type (filename))
 
         debug ("... got mediatype %s from guess_type" % str (attribs.orig_mediatype))
         attribs.orig_url = orig_url
-        attribs.url = url
+        attribs.url = orig_url
         return fp
 
 

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.7.6'
+VERSION = '0.7.7'
 GENERATOR = 'Ebookmaker %s by Marcello Parathoner and Project Gutenberg'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.7.6'
+VERSION = '0.7.7'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
The warning message was erroring because not non-html parsers lack url attributes