### PR TITLE
handle missing files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.7.9 January 6, 2020
+
+- Ebookmaker was failing to make epubs if a linked file was missing. Now it emits an Error message to the log with url of missing file, but goes ahead and makes an epub without it.
+
 0.7.8 January 4, 2020
 
 - updated libgutenberg to 0.5.1

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -20,7 +20,7 @@ import six
 from pkg_resources import resource_listdir, resource_stream # pylint: disable=E0611
 import requests
 
-from libgutenberg.Logger import debug
+from libgutenberg.Logger import debug, error
 from libgutenberg import MediaTypes
 from ebookmaker.CommonCode import Options
 from ebookmaker.Version import VERSION
@@ -144,10 +144,14 @@ class ParserFactory (object):
         """ Open a local file for parsing. """
 
         url = orig_url
-        if url.startswith ('file://'):
-            fp = open (url[7:], "rb")
-        else:
-            fp = open (url, "rb")
+        try:
+            if url.startswith ('file://'):
+                fp = open (url[7:], "rb")
+            else:
+                fp = open (url, "rb")
+        except FileNotFoundError:
+            fp = None
+            error ('Missing file: %s' % url)
         attribs.orig_mediatype = attribs.HeaderElement (MediaTypes.guess_type (url))
 
         debug ("... got mediatype %s from guess_type" % str (attribs.orig_mediatype))

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.7.8'
-GENERATOR = 'Ebookmaker %s by Marcello Parathoner and Project Gutenberg'
+VERSION = '0.7.9'
+GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -104,18 +104,17 @@ class Parser (ParserBase):
 
     def get_image_dimen (self):
         if self.dimen is None:
-            image = Image.open (six.BytesIO (self.image_data))
-            self.dimen = image.size
+            if self.image_data:
+                image = Image.open (six.BytesIO (self.image_data))
+                self.dimen = image.size
+            else:
+                self.dimen = (0, 0)  # broken image
         return self.dimen
 
 
     def pre_parse (self):
         if self.image_data is None:
             self.image_data = self.bytes_content ()
-
-        # FIXME: why did we need this?
-        #if self.image_data is None:
-        #    self.broken_image ()
 
 
     def parse (self):

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -204,6 +204,8 @@ class ParserBase (object):
         """ Get document content as raw bytes. """
 
         if self.buffer is None:
+            if self.fp is None:
+                return b''
             try:
                 debug ("Fetching %s ..." % self.attribs.url)
                 self.buffer = self.fp.read ()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.7.8'
+VERSION = '0.7.9'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
Ebookmaker was failing to make epubs if a linked file was missing. Changed so that it emits an Error message to the log with url of missing file, but makes the epub without it.