### PR TITLE
Mostly css handling improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+0.7.10 January 9, 2020
+
+- build failures on our production system suggest that the parser's output for empty style elements may be os-dependent. Parser now handles style elements with null text.
+- allow the build to succeed even if a css file is missing
+- allow px only in border properties. see discussion below
+- fix false encoding error (complaining about "Klingon") when content file is missing
+
+Ebookmaker has been removing any css rules that use 'px' measurements. 'px' measurements are discouraged in css styles for epub because of poor scaling when user changes font size. However fixed lengths are still useful in properties such as table borders. see discussion on DP forum:
+https://www.pgdp.net/phpBB3/viewtopic.php?f=3&t=41237&p=1188773&hilit=windymilla#p1188746
+
 0.7.9 January 6, 2020
 
 - Ebookmaker was failing to make epubs if a linked file was missing. Now it emits an Error message to the log with url of missing file, but goes ahead and makes an epub without it.

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.7.9'
+VERSION = '0.7.10'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/CSSParser.py
+++ b/ebookmaker/parsers/CSSParser.py
@@ -50,7 +50,11 @@ class Parser (ParserBase):
         if self.fp:
             self.sheet = parser.parseString (self.unicode_content())
         else:
-            self.sheet = parser.parseUrl (self.attribs.url)
+            try:
+                self.sheet = parser.parseUrl (self.attribs.url)
+            except ValueError:
+                logging.error ('Missing file: %s' % self.attribs.url)
+                return
             
         self.attribs.mediatype = parsers.ParserAttributes.HeaderElement ('text/css')
         self.unpack_media_handheld (self.sheet)

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -227,7 +227,11 @@ class ParserBase (object):
                     self.decode ('windows-1252'))
 
             if not data:
-                raise UnicodeError ("Text in Klingon encoding ... giving up.")
+                if data == '':
+                    info ('Continuing parse despite missing file')
+                    self.unicode_buffer = ''
+                else:
+                    raise UnicodeError ("Text in Klingon encoding ... giving up.")
 
             # normalize line-endings
             if '\r' in data or '\u2028' in data:

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -854,10 +854,9 @@ class Writer (writers.HTMLishWriter):
                                     'background-attachment', 'background-repeat'):
                         debug ("Dropping property %s" % p.name)
                         rule.style.removeProperty (p.name)
-
-                    # support for px measurement is now universal
-                    # elif p.value.endswith ('px'):
-                        # rule.style.removeProperty (p.name)
+                    elif 'border' not in p.name and 'px' in p.value:
+                        debug ("Dropping property with px value %s" % p.name)
+                        rule.style.removeProperty (p.name)
 
         # debug ("exit fix_incompatible_css")
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -869,14 +869,15 @@ class Writer (writers.HTMLishWriter):
 
         for style in xpath (xhtml, "//xhtml:style"):
             p = parsers.CSSParser.Parser ()
-            p.parse_string (style.text)
+            if style.text: # try to fix os-dependent empty style bug 
+                p.parse_string (style.text)
 
-            for rule in p.sheet:
-                if rule.type == rule.STYLE_RULE:
-                    for p in rule.style:
-                        if p.name in ('float', 'position'):
-                            classes.update (regex.findall (rule.selectorList.selectorText))
-                            break
+                for rule in p.sheet:
+                    if rule.type == rule.STYLE_RULE:
+                        for p in rule.style:
+                            if p.name in ('float', 'position'):
+                                classes.update (regex.findall (rule.selectorList.selectorText))
+                                break
 
         return classes
 
@@ -889,13 +890,14 @@ class Writer (writers.HTMLishWriter):
 
         for style in xpath (xhtml, "//xhtml:style"):
             p = parsers.CSSParser.Parser ()
-            p.parse_string (style.text)
-            try:
-                # pylint: disable=E1103
-                style.text = p.sheet.cssText.decode ('utf-8')
-            except (ValueError, UnicodeError):
-                debug ("CSS:\n%s" % p.sheet.cssText)
-                raise
+            if style.text: # try to fix os-dependent empty style bug
+                p.parse_string (style.text)
+                try:
+                    # pylint: disable=E1103
+                    style.text = p.sheet.cssText.decode ('utf-8')
+                except (ValueError, UnicodeError):
+                    debug ("CSS:\n%s" % p.sheet.cssText)
+                    raise
 
         # debug ("exit fix_style_elements")
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -854,8 +854,10 @@ class Writer (writers.HTMLishWriter):
                                     'background-attachment', 'background-repeat'):
                         debug ("Dropping property %s" % p.name)
                         rule.style.removeProperty (p.name)
-                    elif p.value.endswith ('px'):
-                        rule.style.removeProperty (p.name)
+
+                    # support for px measurement is now universal
+                    # elif p.value.endswith ('px'):
+                        # rule.style.removeProperty (p.name)
 
         # debug ("exit fix_incompatible_css")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.7.9'
+VERSION = '0.7.10'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
- build failures on our production system suggest that the parser's output for empty style elements may be os-dependent. Parser now handles style elements with null text.
- allow the build to succeed even if a css file is missing
- allow px only in border properties. see discussion below
- fix false encoding error (complaining about "Klingon") when content file is missing

Ebookmaker has been removing any rules that use 'px' measurements. 'px' measurements are discouraged in css styles because of poor scaling when user changes font size. However fixed lengths are still useful in properties such as table borders. see discussion on DP forum:
https://www.pgdp.net/phpBB3/viewtopic.php?f=3&t=41237&p=1188773&hilit=windymilla#p1188746