### PR TITLE
support ebook-convert

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.8.0 January 10, 2020
+- support ebook-convert tool from Calibre as alternative to kindlegen
+
+    To use calibre instead of kindlegen
+
+    1. install calibre
+    2. change MOBIGEN setting to 'ebook-convert' or the path to ebook-convert
+
 0.7.10 January 9, 2020
 
 - build failures on our production system suggest that the parser's output for empty style elements may be os-dependent. Parser now handles style elements with null text.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also it builds HTML4, EPUB2, Kindle, and PDF files from reST sources.
 
 * Python2 >= 2.7 or Python3 >= 3.6
 * HTMLTidy (http://binaries.html-tidy.org/),
-* Kindlegen (https://www.amazon.com/gp/feature.html/?docId=1000765211),
+* Kindlegen (https://www.amazon.com/gp/feature.html/?docId=1000765211) or Calibre (https://calibre-ebook.com/)
 * TexLive (to build from TeX), and
 * groff (not sure when this is needed).
 

--- a/ebookmaker.conf
+++ b/ebookmaker.conf
@@ -28,7 +28,7 @@
 
 [PATHS]
 # proxies: None
-# xelatex: 'xelatex'
-# mobigen: 'kindlegen'
-# groff: 'groff'
+# xelatex: xelatex
+# mobigen: kindlegen  # can also be a path to Calibre's ebook-convert
+# groff: groff
 # rhyming_dict: None

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.7.10'
+VERSION = '0.8.0'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/writers/KindleWriter.py
+++ b/ebookmaker/writers/KindleWriter.py
@@ -36,17 +36,28 @@ class Writer (BaseWriter):
         try:
             cwd = os.getcwd ()
             os.chdir (job.outputdir)
-
-            kindlegen = subprocess.Popen (
-                [
-                    options.config.MOBIGEN,
-                    '-o', os.path.basename (job.outputfile),
-                    job.url
-                ],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-            )
+            if 'ebook-convert' in options.config.MOBIGEN:
+                kindlegen = subprocess.Popen (
+                    [
+                        options.config.MOBIGEN,
+                        job.url,
+                        os.path.basename (job.outputfile),
+                    ],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
+                )
+            else:
+                kindlegen = subprocess.Popen (
+                    [
+                        options.config.MOBIGEN,
+                        '-o', os.path.basename (job.outputfile),
+                        job.url
+                    ],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
+                )
 
         except OSError as what:
             os.chdir (cwd)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.7.10'
+VERSION = '0.8.0'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
to use calibre instead of kindlegen
1. install calibre
2. change MOBIGEN setting  to 'ebook-convert' or the path to ebook-convert