### PR TITLE
stop including media from remote websites unless in included urls

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.8.1 January 16, 2020
+- Ebookmaker has been downloading and including in epubs embedded media from arbitrary websites, for example, images. This has caused build errors when a remote site goes away. ebookmaker has command line parameters that allow include and exclude urls that have governed document files; these same rules now apply to media files.
+
+  In general, PG books should not embed media from other sites.
+
 0.8.0 January 10, 2020
 - support ebook-convert tool from Calibre as alternative to kindlegen
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
-0.8.1 January 16, 2020
+0.8.2 January 16, 2020
+- refined embedded media error message to include referrer
+- added external link warning
+
+0.8.1 January 15, 2020
 - Ebookmaker has been downloading and including in epubs embedded media from arbitrary websites, for example, images. This has caused build errors when a remote site goes away. ebookmaker has command line parameters that allow include and exclude urls that have governed document files; these same rules now apply to media files.
 
   In general, PG books should not embed media from other sites.

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -20,7 +20,7 @@ from six.moves import urllib
 
 import libgutenberg.GutenbergGlobals as gg
 from libgutenberg.GutenbergGlobals import NS
-from libgutenberg.Logger import debug, warning
+from libgutenberg.Logger import debug, warning, error
 from libgutenberg import MediaTypes
 
 from ebookmaker import parsers
@@ -126,6 +126,9 @@ class Spider (object):
             if not self.is_included_url (attribs):
                 return
         if not self.is_included_mediatype (attribs) and not self.is_included_relation (attribs):
+            return
+        elif not self.is_included_url (attribs):
+            error ('Failed for embedded media from disallowed location: %s' % attribs.url)
             return
 
         queue.append ((depth, attribs))

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -124,11 +124,12 @@ class Spider (object):
             if depth >= self.max_depth:
                 return
             if not self.is_included_url (attribs):
+                warning ('External link in %s: %s' % (attribs.referrer, attribs.url))
                 return
         if not self.is_included_mediatype (attribs) and not self.is_included_relation (attribs):
             return
         elif not self.is_included_url (attribs):
-            error ('Failed for embedded media from disallowed location: %s' % attribs.url)
+            error ('Failed for embedded media in %s from disallowed location: %s' % (attribs.referrer, attribs.url))
             return
 
         queue.append ((depth, attribs))

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.8.0'
+VERSION = '0.8.1'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.0'
+VERSION = '0.8.1'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
ebookmaker has been downloading and including in epubs embedded media from arbitrary websites, for example, images. This has caused build errors when a remote site goes away. ebookmaker has command line parameters that allow include and exclude urls that have governed document files; these same rules now apply to media files. 

In general, PG books should not embed media from other sites.