### PR TITLE
fix unbalanced brace in tex writer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.8.4 January 23, 2020
+- fixed bugs in rst->tex conversion
+    - class = 'medium' extra '}'
+    - removed '%' in noindent
+
 0.8.3 January 21, 2020
 - fixed bug exposed by setting cover with a command line argument
 

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.8.3'
+VERSION = '0.8.4'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/mydocutils/writers/xetex.py
+++ b/ebookmaker/mydocutils/writers/xetex.py
@@ -455,7 +455,7 @@ class Translator (writers.Translator):
         self.register_class ('inline', 'xx-large',    r'{\Huge\strut{',         r'}}')
         self.register_class ('inline', 'x-large',     r'{\LARGE\strut{',        r'}}')
         self.register_class ('inline', 'large',       r'{\Large\strut{',        r'}}')
-        self.register_class ('inline', 'medium',      r'{\normalsize ',   r'}}')
+        self.register_class ('inline', 'medium',      r'{\normalsize{ ',   r'}}')
         self.register_class ('inline', 'small',       r'{\footnotesize{', r'}}')
         self.register_class ('inline', 'x-small',     r'{\scriptsize{',   r'}}')
         self.register_class ('inline', 'xx-small',    r'{\tiny{',         r'}}')

--- a/ebookmaker/mydocutils/writers/xetex.py
+++ b/ebookmaker/mydocutils/writers/xetex.py
@@ -525,7 +525,7 @@ class Translator (writers.Translator):
 
     def output_noindent (self):
         if not self.indent_p:
-            self.context.append ('{\\noindent}%\n')
+            self.context.append ('{\\noindent}\n')
             self.indent_p = True
 
     def ta (self, indent, text):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.3'
+VERSION = '0.8.4'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
- fixed bugs in rst->tex conversion
    - class = 'medium' extra '}'
    - removed '%' in noindent
