### PR TITLE
Fix reversion in 0.8.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.8.11 May 4, 2020
+- It turns out that ebookmaker gets called both with bare paths and file: urls depending on ebookconverter config files. So 0.8.10 broke on the production machine, though it seemed just fine on mac and windows. So we went back to the drawing board to figure out how to support posix and windows, with or without windows mount points (not sure if that's the right term), file:/// urls and bare paths. We also figured out some issues involving spaces in paths.
+
 0.8.10 April 30, 2020
 - fixed numerous file path nits on Windows
     - kindlegen

--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ Travis-CI will run tests on branches committed in the gutenbergtools org
     - Look in `C:\Users\myname\.virtualenvs\` and find the name of your virtualev it should be something like `ebookmaker-cgaQuYhi`
     - Type `pipenv run python C:\Users\myname\.virtualenvs\<name of vitualenv>\Scripts\ebookmaker --version` to check ebookmaker version. 
 17. If there's error like like no "cairo" or "cairo-2" found, check if your libcairo and libcairo-2 path exist. If they do, edit dlopen in  _init_.py in cairocffi package. Return the path found by ctypes.util.find_library directly instead of calling ffi.dlopen(path).
+18. If command input directory, such as `--output-dir=`, has folder name that contains space, use `"` for it, like `--output-dir="C:\your foldername"`. 
+19. Directory input for ebookmaker on Windows MUST end with foldername instead of `\` on Linux/Mac or erorr will be raised.

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -20,6 +20,7 @@ import datetime
 import hashlib
 import logging
 import os.path
+import re
 import sys
 
 import six
@@ -138,11 +139,11 @@ def elect_coverpage(spider, url):
             return
         if options.outputdir:
             dir = options.outputdir
-        elif:
-            url = url[8:] if url.startswith('file:///') else url
-            dir = os.path.dirname(os.path.abspath(url))
+        elif url.startswith('file://'):
+            dir = os.path.dirname(os.path.abspath(url[7:]))
+        elif url.startswith('file:'):
+            dir = os.path.dirname(os.path.abspath(url[5:]))
         else:
-            url = url[6:] if url.startswith('file:/') else url
             dir = os.path.dirname(os.path.abspath(url))
         debug('generating cover in %s' % dir)
         cover_url = generate_cover(dir)
@@ -494,7 +495,7 @@ def config():
         }
     )))
 
-    if '://' not in options.url:
+    if not re.search(r'^(https?|file):', options.url):
         options.url = os.path.abspath(options.url)
 
 

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -138,8 +138,11 @@ def elect_coverpage(spider, url):
             return
         if options.outputdir:
             dir = options.outputdir
-        else:
+        elif:
             url = url[8:] if url.startswith('file:///') else url
+            dir = os.path.dirname(os.path.abspath(url))
+        else:
+            url = url[6:] if url.startswith('file:/') else url
             dir = os.path.dirname(os.path.abspath(url))
         debug('generating cover in %s' % dir)
         cover_url = generate_cover(dir)

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -145,18 +145,20 @@ class ParserFactory(object):
 
         url = orig_url
         try:
-            if url.startswith('file:///'):
-                fp = open(url[8:], "rb")
-            elif url.startswith('file:/'):
-                fp = open(url[6:], "rb")
-            else:
-                fp = open(url, "rb")
+            fp = urllib.request.urlopen(url)
         except FileNotFoundError:
             fp = None
             error('Missing file: %s' % url)
         except IsADirectoryError:
             fp = None
             error('Missing file is a directory: %s' % url)
+        except ValueError:  # just a path
+            try:
+                fp = open(url, 'rb')
+            except:
+                fp = None
+                error('Missing file: %s' % url)
+            
         attribs.orig_mediatype = attribs.HeaderElement(MediaTypes.guess_type(url))
 
         debug("... got mediatype %s from guess_type" % str(attribs.orig_mediatype))

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -13,6 +13,7 @@ Distributable under the GNU General Public License Version 3 or newer.
 
 
 import os.path
+import re
 
 from six.moves import urllib
 import six

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -169,8 +169,7 @@ class ParserFactory(object):
         attribs.orig_mediatype = attribs.HeaderElement(MediaTypes.guess_type(url))
 
         debug("... got mediatype %s from guess_type" % str(attribs.orig_mediatype))
-        attribs.orig_url = orig_url
-        attribs.url = url
+        attribs.orig_url = attribs.url = url
         return fp
 
 

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.8.10'
+VERSION = '0.8.11'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -27,7 +27,7 @@ from libgutenberg.Logger import info, debug, warning, error
 from libgutenberg.MediaTypes import mediatypes as mt
 
 from ebookmaker import parsers
-from ebookmaker.parsers import HTMLParserBase, webify_url
+from ebookmaker.parsers import HTMLParserBase
 
 mediatypes = ('text/html', mt.xhtml)
 

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -90,7 +90,7 @@ def webify_url(url):
         return 'file:///' + url.replace(os.path.sep, '/')
     url = os.path.abspath(url).replace(os.path.sep, '/')
     if url.startswith('/'):
-        url = url[:1]
+        url = url[1:]
     return 'file:///' + url
 
 

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -84,9 +84,14 @@ def webify_url(url):
     """ make the url for a parser, accounting for platform """
     if re.search(r'^https?://', url):
         return url
+    if url.startswith('file:'):
+        return url
     if re.search(r'^[a-zA-z]:', url):
         return 'file:///' + url.replace(os.path.sep, '/')
-    return os.path.abspath(url).replace(os.path.sep, '/')
+    url = os.path.abspath(url).replace(os.path.sep, '/')
+    if url.startswith('/'):
+        url = url[:1]
+    return 'file:///' + url
 
 
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -1043,6 +1043,8 @@ class Writer(writers.HTMLishWriter):
         """
         if match_link_url.match(url):
             return url
+        if url.startswith('file://'):
+            url = url[7:]
         def escape(matchobj):
             """ Escape a char. """
             return '@%x' % ord(matchobj.group(0))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.10'
+VERSION = '0.8.11'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
It turns out that ebookmaker gets called both with bare paths and file: urls depending on ebookconverter config files. So 0.8.10 broke on the production machine, though it seemed just fine on mac and windows. So we went back to the drawing board to figure out how to support posix and windows, with or without windows mount points (not sure if that's the right term), file:/// urls and bare paths. We also figured out some issues involving spaces in paths.