### PR TITLE
0.9.0 Changes in image handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,20 @@
+0.9.0 June 2, 2020
+Image handling has changed starting with 0.9
+- linked images (image files as targets of links) are now wrapped in html, fixing display in ADE.
+- linked images are compressed to 1MB if possible (changed from 128K)
+- inline images are compressed to 256K if possible (changed from 128K)
+- all images are limited to 5000x5000 pixels (was 800 x 1280)
+- PNG images are scaled to meet the image filesize targets (previously no scaling of PNG images)
+- L format JPEG images (greyscale) are no longer converter to RBG
+- generated covers are no 1200 x 1800
+- covers and "important" images in noimages builds are scaled to 64K (previously no scaling)
+
+General bug fixes
+- eliminated double parsing due to first pass using raw paths
+- when tidy fails, the (huge) error trace is only logged once.
+- generated html is no longer overwritten by empty results
+
+
 0.8.12 May 5, 2020
 - corrected the exception to catch for missing files
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ Travis-CI will run tests on branches committed in the gutenbergtools org
     - Look in `C:\Users\myname\.virtualenvs\` and find the name of your virtualev it should be something like `ebookmaker-cgaQuYhi`
     - Type `pipenv run python C:\Users\myname\.virtualenvs\<name of vitualenv>\Scripts\ebookmaker --version` to check ebookmaker version. 
 17. If there's error like like no "cairo" or "cairo-2" found, check if your libcairo and libcairo-2 path exist. If they do, edit dlopen in  _init_.py in cairocffi package. Return the path found by ctypes.util.find_library directly instead of calling ffi.dlopen(path).
+18. If command input directory, such as `--output-dir=`, has folder name that contains space, use `"` for it, like `--output-dir="C:\your foldername"`. 
+19. Directory input for ebookmaker on Windows MUST end with foldername instead of `\` on Linux/Mac or erorr will be raised.

--- a/docs/images.md
+++ b/docs/images.md
@@ -29,7 +29,7 @@ Images submitted for use in HTML should be sized and compressed so that load tim
 
 Ebookmaker 0.9 has relaxed some limits on image sizes used inside EPUB and Kindle, considering advances in device power and network speed. Before version 0.9, any image or cover larger than 128KB was compressed to  fit under 128KB. Similarly, images and covers wider than 800 px or taller than 1280 px were proportionately scaled down to fit. In version 0.9, the limits depend on the type of the image. 
 
-- inline images are compressed if they are larger than 256KB and scaled if they are larger than 800x1280.
+- inline images are compressed if they are larger than 256KB and scaled if they are larger than 5000 x 5000.
 - linked images and cover images are compressed if they are larger than 1MB and scaled if they are larger than 5000x5000
 
 Industry specifications for book cover images have changed in the last few years. Amazon now requires that commercial ebook covers have _minimum_ dimensions of "at least 1200 pixels in width or 1800 pixels in height." They're more relaxed for self-published covers; KDP suggests minimum dimensions of 625 x 1000 px and ideal dimensions of 1600 x 2560. New Project Gutenberg books should have covers of quality commensurate with industry practice.

--- a/docs/images.md
+++ b/docs/images.md
@@ -2,7 +2,7 @@ IMAGES AND COVERS
 
 As of EbookMaker 0.9, image filesize and dimension limits are being set differently.
 
-EbookMaker now considers three types of images it finds in html, and handles them differently from other images:
+EbookMaker now considers three types of images it finds in html, and handles them each differently.:
 
 1. inline images
     `<img src="unicorn.png" alt="Image of a Unicorn" />`
@@ -41,6 +41,8 @@ Suggested Guidelines for cover and image submissions to Project Gutenberg:
 1. Submitted cover images should be at least 625 x 1000 px and ideally larger. The should be not exceed 1MB in size unless specified by a coverpage relation.
 
 2. Submitted images should be less than 256KB for inline images and less than 1MB for linked images.
+
+3. Display sizes for images should be set using relative units i.e. `ems`, and Project Gutenberg does not need to restrict pixel sizes for submitted images.
 
 
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,47 @@
+IMAGES AND COVERS
+
+As of EbookMaker 0.9, image filesize and dimension limits are being set differently.
+
+EbookMaker now considers three types of images it finds in html, and handles them differently from other images:
+
+1. inline images
+    `<img src="unicorn.png" alt="Image of a Unicorn" />`
+2. linked images
+    `<a href="bigunicorn.png" title="Expanded Image of a Unicorn" />Click for larger Unicorn</a>`
+3. cover images
+   These can come in 4 flavors (in priority order):
+    1. coverpage relation
+        `<link href="unicorn_image.jpg" rel="coverpage" />`  or 
+    2. coverpage id
+        `<img src="unicorn_image.jpg" id="coverpage" alt="front jacket" />`
+    3. image with 'cover' in the url
+        `<img src="unicorn_cover.jpg" alt="front jacket" />`
+    4. image with 'title' in the url
+        `<img src="unicorn_titlepage.jpg" alt="front jacket" />`
+
+Ebookmaker doesn't like to have duplicate covers, so it takes the first cover of sufficient size (>200x200), creates a cover wrapper for it, and tries to remove duplicates.
+
+Ebookmaker doesn't touch HTML or image files submitted to Project Gutenberg and displayed as HTML books. However, it transforms both HTML and image files for inclusion in EPUB and Kindle. Cover images displayed on Project Gutenberg are sized and processed by EbookMaker, and when no cover is present, an abstract cover is generated for the book.
+
+For compatibility, Ebookmaker > 0.9 creates "wrapper" files for linked images. Submitters do not need to create wrapper files.
+
+Images submitted for use in HTML should be sized and compressed so that load times are reasonably short and they look good on screens.
+
+Ebookmaker 0.9 has relaxed some limits on image sizes used inside EPUB and Kindle, considering advances in device power and network speed. Before version 0.9, any image or cover larger than 128KB was compressed to  fit under 128KB. Similarly, images and covers wider than 800 px or taller than 1280 px were proportionately scaled down to fit. In version 0.9, the limits depend on the type of the image. 
+
+- inline images are compressed if they are larger than 256KB and scaled if they are larger than 800x1280.
+- linked images and cover images are compressed if they are larger than 1MB and scaled if they are larger than 5000x5000
+
+Industry specifications for book cover images have changed in the last few years. Amazon now requires that commercial ebook covers have _minimum_ dimensions of "at least 1200 pixels in width or 1800 pixels in height." They're more relaxed for self-published covers; KDP suggests minimum dimensions of 625 x 1000 px and ideal dimensions of 1600 x 2560. New Project Gutenberg books should have covers of quality commensurate with industry practice.
+
+Since cover images specified by the coverpage relation are not displayed in HTML, there is no need to limit their size (within reason!!!)
+
+Suggested Guidelines for cover and image submissions to Project Gutenberg:
+
+1. Submitted cover images should be at least 625 x 1000 px and ideally larger. The should be not exceed 1MB in size unless specified by a coverpage relation.
+
+2. Submitted images should be less than 256KB for inline images and less than 1MB for linked images.
+
+
+
+

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -157,7 +157,7 @@ def elect_coverpage(spider, url):
 
 def generate_cover(dir):
     try:
-        cover_image = Cover.draw(options.dc)
+        cover_image = Cover.draw(options.dc, cover_width=1200, cover_height=1800)
         cover_url = os.path.join(dir, make_output_filename('cover', options.dc))
         with open(cover_url, 'wb+') as cover:
             cover_image.save(cover)

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -75,7 +75,7 @@ class ParserFactory(object):
     @classmethod
     def create(cls, url, attribs=None):
         """ Create an appropriate parser. """
-
+        url = parsers.webify_url(url)
         if attribs is None:
             attribs = parsers.ParserAttributes()
 

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -96,7 +96,8 @@ class Spider(object):
 
                 tag = elem.tag
                 if tag == NS.xhtml.a:
-                    if self.is_image(new_attribs) and self.is_included_url(new_attribs):
+                    if self.is_image(new_attribs) and self.is_included_url(new_attribs) and \
+                            self.is_included_mediatype(new_attribs):
                         # need to wrap an image
                         wrapper_parser = parsers.WrapperParser.Parser(new_attribs)
                         self.parsed_urls.add(wrapper_parser.attribs.url)

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -100,9 +100,10 @@ class Spider(object):
                             self.is_included_mediatype(new_attribs):
                         # need to wrap an image
                         wrapper_parser = parsers.WrapperParser.Parser(new_attribs)
-                        self.parsed_urls.add(wrapper_parser.attribs.url)
-                        ParserFactory.parsers[wrapper_parser.attribs.url] = wrapper_parser
-                        self.parsers.append(wrapper_parser)
+                        if wrapper_parser.attribs.url not in self.parsed_urls:
+                            ParserFactory.parsers[wrapper_parser.attribs.url] = wrapper_parser
+                            self.parsers.append(wrapper_parser)
+                            self.parsed_urls.add(wrapper_parser.attribs.url)
                         elem.set('href', wrapper_parser.attribs.url)
                         new_attribs.referrer = wrapper_parser.attribs.url
                         elem.set('title', wrapper_parser.attribs.title)

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -105,7 +105,7 @@ class Spider(object):
                         elem.set('href', wrapper_parser.attribs.url)
                         new_attribs.referrer = wrapper_parser.attribs.url
                         elem.set('title', wrapper_parser.attribs.title)
-                        self.enqueue(queue, depth, new_attribs, False)
+                        self.enqueue(queue, depth + 1, new_attribs, False)
                     else:
                         self.enqueue(queue, depth + 1, new_attribs, True)
                         

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -24,7 +24,7 @@ from libgutenberg.Logger import debug, warning, error
 from libgutenberg import MediaTypes
 
 from ebookmaker import parsers
-from ebookmaker import ParserFactory
+from ebookmaker.ParserFactory import ParserFactory
 
 
 class Spider(object):
@@ -66,7 +66,7 @@ class Spider(object):
             if url in self.parsed_urls:
                 continue
 
-            parser = ParserFactory.ParserFactory.create(url, attribs)
+            parser = ParserFactory.create(url, attribs)
 
             # Maybe the url was redirected to something we already have?
             url = parser.attribs.url

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -118,7 +118,7 @@ class Spider(object):
 
 
     def enqueue(self, queue, depth, attribs, is_doc):
-        """ Enque url for parsing. """
+        """ Enqueue url for parsing."""
         if is_doc:
             if not self.is_included_url(attribs):
                 warning('External link in %s: %s' % (attribs.referrer, attribs.url))

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.8.12'
+VERSION = '0.9.0'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -181,7 +181,7 @@ class Parser (HTMLParserBase):
                     error (line)
 
         if tidy.returncode == 2:
-            raise ValueError ('Tidy tried valiently, but the patient died.")
+            raise ValueError ("Tidy tried valiently, but the patient died.")
 
         return html.decode ('utf-8')
 

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -181,7 +181,7 @@ class Parser (HTMLParserBase):
                     error (line)
 
         if tidy.returncode == 2:
-            raise ValueError (stderr)
+            raise ValueError ('Tidy tried valiently, but the patient died.")
 
         return html.decode ('utf-8')
 

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -357,7 +357,7 @@ class Parser (HTMLParserBase):
             return
         
         for coverpage in coverpages:
-            url = coverpage.get ('src')
+            url = coverpage.get ('href')
             debug ("Found link to coverpage %s." % url)
             return   # already provided by user
 

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -44,18 +44,34 @@ class Parser (ParserBase):
     def resize_image (self, max_size, max_dimen, output_format = None):
         """ Create a new parser with a resized image. """
 
+        def scale_image(image, scale):
+            was = ''
+            if scale < 1.0:
+                dimen = (int (image.size[0] * scale), int(image.size[1] * scale))
+                was = "(was %d x %d scale=%.2f) " % (image.size[0], image.size[1], scale)
+                image = image.resize(dimen, Image.ANTIALIAS)
+            return was, image
+
+        def get_image_data(image, format_, quality=95):
+            buf = six.BytesIO()
+            if format_ == 'png':
+                image.save(buf, 'png', optimize=True)
+            else:
+                image.save(buf, 'jpeg', quality=quality)
+            return buf.getvalue()
+
         new_parser = Parser ()
 
         try:
-            image = Image.open (six.BytesIO (self.image_data))
+            unsized_image = Image.open(six.BytesIO(self.image_data))
 
-            format_ = image.format
+            format_ = unsized_image.format.lower()
             if output_format:
                 format_ = output_format
             if format_ == 'gif':
                 format_ = 'png'
-            if format_ == 'jpeg' and image.mode.lower () != 'rgb':
-                image = image.convert ('RGB')
+            if format_ == 'jpeg' and unsized_image.mode.lower() != 'rgb':
+                unsized_image = unsized_image.convert('RGB')
 
             if 'dpi' in image.info:
                 del image.info['dpi']
@@ -67,22 +83,23 @@ class Parser (ParserBase):
             scale = min (scale, max_dimen[0] / float (image.size[0]))
             scale = min (scale, max_dimen[1] / float (image.size[1]))
 
-            was = ''
-            if scale < 1.0:
-                dimen = (int (image.size[0] * scale), int (image.size[1] * scale))
-                was = "(was %d x %d scale=%.2f) " % (image.size[0], image.size[1], scale)
-                image = image.resize (dimen, Image.ANTIALIAS)
+            was, image = scale_image(unsized_image, scale)
+            data = get_image_data(image, format_)
 
-            # find best quality that fits into max_size
-            data = self.image_data
-            if (scale < 1.0) or (len (self.image_data) > max_size):
-                for quality in (90, 85, 80, 70, 60, 50, 40, 30, 20, 10):
-                    buf = six.BytesIO ()
-                    image.save (buf, format_, quality = quality)
-                    data = buf.getvalue ()
-                    if len (data) <= max_size:
-                        was += 'q=%d' % quality
-                        break
+            if format_ == 'png':
+                # scale it till it fits into max_size
+                while len(data) > max_size and scale > 0.01:
+                    scale = scale * 0.8
+                    was, image = scale_image(unsized_image, scale)
+                    data = get_image_data(image, format_)
+            else:
+                # find best quality that fits into max_size
+                if len(data) > max_size:
+                    for quality in (90, 85, 80, 70, 60, 50, 40, 30, 20, 10):
+                        data = get_image_data(image, format_, quality=quality)
+                        if len(data) <= max_size:
+                            was += 'q=%d' % quality
+                            break
 
             comment = "Image: %d x %d size=%d %s" % (
                         image.size[0], image.size[1], len (data), was)

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -12,6 +12,7 @@ Distributable under the GNU General Public License Version 3 or newer.
 """
 import lxml
 
+from copy import copy
 from ebookmaker.parsers import HTMLParserBase, IMAGE_WRAPPER
 
 mediatypes = ()
@@ -19,7 +20,7 @@ mediatypes = ()
 class Parser(HTMLParserBase):
 
     def __init__(self, attribs):
-        HTMLParserBase.__init__(self, attribs)
+        HTMLParserBase.__init__(self, copy(attribs))
         self.attribs.orig_mediatype = self.attribs.mediatype
         self.src = self.attribs.url
         self.attribs.url = self.wrapper_url(self.attribs.url)
@@ -34,6 +35,8 @@ class Parser(HTMLParserBase):
 
         # mark the image for treatment as a linked image
         attribs.rel.add('linked_image')
+        # set the referrer for the image to this wrapper
+        attribs.referrer = self.attribs.url
 
 
     def unicode_content(self):

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+
+"""
+
+WrapperParser.py
+
+Copyright 2020 by Eric Hellman
+
+Distributable under the GNU General Public License Version 3 or newer.
+
+"""
+import lxml
+
+from ebookmaker.parsers import HTMLParserBase, IMAGE_WRAPPER
+
+mediatypes = ()
+
+class Parser(HTMLParserBase):
+
+    def __init__(self, attribs):
+        HTMLParserBase.__init__(self)
+
+        self.attribs.update(attribs)
+        attribs.rel.add('linked_image')
+        self.src = self.attribs.url
+        self.attribs.referrer = attribs.referrer
+        self.attribs.url = self.wrapper_url(self.attribs.url)
+        self.attribs.orig_url = self.attribs.url
+        if not self.attribs.title:
+            self.attribs.title = 'linked image'
+        self.xhtml = lxml.etree.fromstring(
+            self.unicode_content(),
+            lxml.html.XHTMLParser(),
+            base_url=self.attribs.url
+        )
+
+
+    def bytes_content(self):
+        return bytes(self.unicode_content(self), 'utf-8')
+
+
+    def unicode_content(self):
+        """ wrapper page content """
+        return IMAGE_WRAPPER.format(src=self.src, title=self.attribs.title)
+
+
+    def wrapper_url(self, img_url):
+        """ make the wrapper url. """
+        return img_url + '.wrap.html'
+
+
+    def make_toc(self, xhtml):
+        return []

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -48,6 +48,8 @@ class Parser(HTMLParserBase):
 
     def wrapper_url(self, img_url):
         """ make the wrapper url. """
+        if self.attribs.id:
+            return '%s.%s.wrap.html' % (img_url, self.attribs.id)
         return img_url + '.wrap.html'
 
 

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -41,7 +41,9 @@ class Parser(HTMLParserBase):
 
     def unicode_content(self):
         """ wrapper page content """
-        return IMAGE_WRAPPER.format(src=self.src, title=self.attribs.title)
+        frag = ('#%s' % self.attribs.id) if self.attribs.id else ''
+        backlink = '<br /><a href="%s%s" title="back" >back</a>' % (self.attribs.referrer, frag)
+        return IMAGE_WRAPPER.format(src=self.src, title=self.attribs.title, backlink=backlink)
 
 
     def wrapper_url(self, img_url):

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -19,12 +19,9 @@ mediatypes = ()
 class Parser(HTMLParserBase):
 
     def __init__(self, attribs):
-        HTMLParserBase.__init__(self)
-
-        self.attribs.update(attribs)
-        attribs.rel.add('linked_image')
+        HTMLParserBase.__init__(self, attribs)
+        self.attribs.orig_mediatype = self.attribs.mediatype
         self.src = self.attribs.url
-        self.attribs.referrer = attribs.referrer
         self.attribs.url = self.wrapper_url(self.attribs.url)
         self.attribs.orig_url = self.attribs.url
         if not self.attribs.title:
@@ -35,9 +32,8 @@ class Parser(HTMLParserBase):
             base_url=self.attribs.url
         )
 
-
-    def bytes_content(self):
-        return bytes(self.unicode_content(self), 'utf-8')
+        # mark the image for treatment as a linked image
+        attribs.rel.add('linked_image')
 
 
     def unicode_content(self):

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -75,6 +75,23 @@ BOGUS_CHARSET_NAMES = {'iso-latin-1': 'iso-8859-1',
                        'macintosh': 'mac_roman',
                        }
 
+IMAGE_WRAPPER = """<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>{title}</title>
+    <style type="text/css">
+       div {{ text-align: center }}
+       img {{ max-width: 100%; }}
+    </style>
+  </head>
+  <body>
+    <div>
+      <img src="{src}" alt="{title}" />
+    </div>
+  </body>
+</html>"""
+
 # exported
 em = ElementMaker(makeelement=lxml.html.xhtml_parser.makeelement,
                   namespace=str(NS.xhtml),

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -141,11 +141,12 @@ class ParserAttributes(object): # pylint: disable=too-few-public-methods
         self.id = None
         self.rel = set()
         self.referrer = None
+        self.title = None
 
 
     def update(self, more_attribs):
         for k, v in vars(more_attribs).items():
-            if v is not None:
+            if v:
                 setattr(self, k, v)
 
 

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -80,14 +80,11 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{title}</title>
-    <style type="text/css">
-       div {{ text-align: center }}
-       img {{ max-width: 100%; }}
-    </style>
   </head>
   <body>
-    <div>
-      <img src="{src}" alt="{title}" />
+    <div style="text-align: center">
+      <img src="{src}" alt="{title}" style="max-width: 100%; " />
+      {backlink}
     </div>
   </body>
 </html>"""

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -44,16 +44,14 @@ from ebookmaker.Version import VERSION, GENERATOR
 options = Options()
 
 MAX_CHUNK_SIZE = 300 * 1024  # bytes
-
-MAX_IMAGE_SIZE = 127 * 1024  # in bytes
+MAX_NOIMAGE_SIZE = 64 * 1024 - 1 # bytes, used for covers and important images in "noimages epubs"
+MAX_IMAGE_SIZE = 512 * 1024 - 1  # in bytes, used for Kindle, too.
+LINKED_IMAGE_SIZE = 1024 * 1024 - 1  # in bytes
 
 MAX_IMAGE_DIMEN = (800, 1280)  # in pixels
-MAX_COVER_DIMEN = (800, 1280)  # in pixels
+LINKED_IMAGE_DIMEN = (5000, 5000)  # in pixels
+MAX_COVER_DIMEN = MAX_IMAGE_DIMEN
 
-MAX_IMAGE_SIZE_KINDLE = 127 * 1024  # in bytes
-
-MAX_IMAGE_DIMEN_KINDLE = (1200, 1920)  # Kindle Fire HD 8.9" in pixels
-MAX_COVER_DIMEN_KINDLE = (1200, 1920)  #
 
 # iPhone 3G:    320x480x?
 # Kindle 2:     600x800x16
@@ -1197,18 +1195,20 @@ class Writer(writers.HTMLishWriter):
             for p in job.spider.parsers:
                 if hasattr(p, 'resize_image'):
                     if 'coverpage' in p.attribs.rel:
-                        if job.maintype == 'kindle':
-                            np = p.resize_image(MAX_IMAGE_SIZE_KINDLE,
-                                                MAX_COVER_DIMEN_KINDLE, 'jpeg')
+                        if job.subtype == '.noimages':
+                            np = p.resize_image(MAX_NOIMAGE_SIZE, MAX_COVER_DIMEN)
                         else:
                             np = p.resize_image(MAX_IMAGE_SIZE, MAX_COVER_DIMEN)
                         np.id = p.attribs.get('id', 'coverpage')
                         coverpage_url = p.attribs.url
-                    else:
-                        if job.maintype == 'kindle':
-                            np = p.resize_image(MAX_IMAGE_SIZE_KINDLE, MAX_IMAGE_DIMEN_KINDLE)
+                    elif 'linked_image' in p.attribs.rel:
+                        if job.subtype == '.noimages':
+                            np = p.resize_image(MAX_NOIMAGE_SIZE, LINKED_IMAGE_DIMEN)
                         else:
-                            np = p.resize_image(MAX_IMAGE_SIZE, MAX_IMAGE_DIMEN)
+                            np = p.resize_image(LINKED_IMAGE_SIZE, LINKED_IMAGE_DIMEN)
+                        np.id = p.attribs.get('id')
+                    else:
+                        np = p.resize_image(MAX_IMAGE_SIZE, MAX_IMAGE_DIMEN)
                         np.id = p.attribs.get('id')
                     parserlist.append(np)
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -188,7 +188,7 @@ class OEBPSContainer(zipfile.ZipFile):
         """ Add file to zip from bytes string. """
 
         i = self.zi(name)
-        if mediatype and mediatype in (mt.png, mt.gif, mt.jpeg):
+        if mediatype and mediatype in parsers.ImageParser.mediatypes:
             i.compress_type = zipfile.ZIP_STORED
         self.writestr(i, bytes_)
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -134,22 +134,6 @@ OPS_CONTENT_DOCUMENTS = set((
     'application/xml',
 ))
 
-IMAGE_WRAPPER = """<?xml version="1.0"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <title>{title}</title>
-    <style type="text/css">
-       div {{ text-align: center }}
-       img {{ max-width: 100%; }}
-    </style>
-  </head>
-  <body>
-    <div>
-      <img src="{src}" alt="{title}" />
-    </div>
-  </body>
-</html>"""
 
 match_link_url = re.compile(r'^https?://', re.I)
 
@@ -268,7 +252,7 @@ class OEBPSContainer(zipfile.ZipFile):
         filename = 'wrap%04d.html' % self.wrappers
         self.wrappers += 1
         self.add_bytes(filename,
-                       IMAGE_WRAPPER.format(src=img_url, title=img_title),
+                       parsers.IMAGE_WRAPPER.format(src=img_url, title=img_title),
                        mt.xhtml)
         return filename
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -250,7 +250,7 @@ class OEBPSContainer(zipfile.ZipFile):
         filename = 'wrap%04d.html' % self.wrappers
         self.wrappers += 1
         self.add_bytes(filename,
-                       parsers.IMAGE_WRAPPER.format(src=img_url, title=img_title),
+                       parsers.IMAGE_WRAPPER.format(src=img_url, title=img_title, backlink=""),
                        mt.xhtml)
         return filename
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -45,7 +45,7 @@ options = Options()
 
 MAX_CHUNK_SIZE = 300 * 1024  # bytes
 MAX_NOIMAGE_SIZE = 64 * 1024 - 1 # bytes, used for covers and important images in "noimages epubs"
-MAX_IMAGE_SIZE = 512 * 1024 - 1  # in bytes, used for Kindle, too.
+MAX_IMAGE_SIZE = 256 * 1024 - 1  # in bytes, used for Kindle, too.
 LINKED_IMAGE_SIZE = 1024 * 1024 - 1  # in bytes
 
 MAX_IMAGE_DIMEN = (800, 1280)  # in pixels

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -9,7 +9,8 @@ Copyright 2009 by Marcello Perathoner
 
 Distributable under the GNU General Public License Version 3 or newer.
 
-Writes an HTML file
+Writes one HTML file. Currently used only for RST input. 
+Needs revision to use with multi-file books and HTML input.
 
 """
 
@@ -91,7 +92,7 @@ class Writer (writers.HTMLishWriter):
                                            xml_declaration = True)
 
                     self.write_with_crlf (htmlfilename, html)
-
+                    break
             info ("Done HTML file: %s" % htmlfilename)
 
         except Exception as what:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.8.12'
+VERSION = '0.9.0'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
Image handling has changed starting with 0.9
- linked images (image files as targets of links) are now wrapped in html, fixing display in ADE.
- linked images are compressed to 1MB if possible (changed from 128K)
- inline images are compressed to 256K if possible (changed from 128K)
- all images are limited to 5000x5000 pixels (was 800 x 1280)
- PNG images are scaled to meet the image filesize targets (previously no scaling of PNG images)
- L format JPEG images (greyscale) are no longer converter to RBG
- generated covers are no 1200 x 1800
- covers and "important" images in noimages builds are scaled to 64K (previously no scaling)

General bug fixes
- eliminated double parsing due to first pass using raw paths
- when tidy fails, the (huge) error trace is only logged once.
- generated html is no longer overwritten by empty results
