### PR TITLE
Remove stated Python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Also it builds HTML4, EPUB2, Kindle, and PDF files from reST sources.
 
 ## Prerequisites
 
-* Python2 >= 2.7 or Python3 >= 3.6
+* Python3 >= 3.6
 * HTMLTidy (http://binaries.html-tidy.org/),
 * Kindlegen (https://www.amazon.com/gp/feature.html/?docId=1000765211) or Calibre (https://calibre-ebook.com/)
 * TexLive (to build from TeX), and


### PR DESCRIPTION
Use with Python 2.7 is broken at least as of 5958d74e1 which added
the python3-only encoding parameter to setup.py.