### PR TITLE
Only optionally pull in libgutenberg[covers]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,12 @@ setup (
         'roman',
         'requests',
         'six>=1.4.1',
-        'libgutenberg[covers]>=0.5.1',
+        'libgutenberg>=0.5.1',
     ],
+
+    extras_require = {
+        'covers': ['libgutenberg[covers]>=0.5.1'],
+    },
     
     package_data = {
         'ebookmaker.parsers': ['broken.png'],


### PR DESCRIPTION
Right now when we install ebookmaker on Windows it requires Cairo which requires a compiler on Windows which is a 4GB download -- so basically it's a real PITA for your average Windows user to use the current ebookmaker.

The optional [covers] feature in libgutenberg pulls in Cairo for creating covers. Let's make this optional in ebookmaker as well so a default install of ebookmaker doesn't pull in Cairo.

Disclaimer: frustratingly, this only works in theory, because in theory you can now install `ebookmaker[covers]` and it will install `libgutenberg[covers]` and off we go. But despite my testing with pip and pipenv it just installs `libgutenberg` (no covers). According to all the pip docs I've read, this should Just Work. So in practice what this means is that anyone who wants to use covers with ebookmaker will have to install `ebookmaker` *and* `libgutenberg[covers]` (which I confirmed _does_ work). That's annoying and confusing but it drastically decreases the overhead for Windows users and with your use of the Pipfile for production it shouldn't really impact you much.

This MR is mostly to open a discussion for how we can stop ebookmaker from requiring the `covers` extra of `libgutenberg` with what is my best idea at the moment.

CC: @windymilla 
