### PR TITLE
fix png -> jpeg conversion fails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
+0.9.3 June 23, 2020
+- Fix reversion in 0.9.2 which caused CoverWriter in EbookConverter to fail. (It uses ImageParser to convert images from PNG to JPEG
+- add a test to check this
+
 0.9.2 June 19, 2020
-- note that EbookMaker in no longer installable in Python 2.7 (thanks cpeel)
+- note that EbookMaker is no longer installable in Python 2.7 (thanks cpeel)
 - clean up pipfile and gitignore pipfile.lock (thanks cpeel)
 - fixed bug where filepaths need escape in HTML
 - fixed issue where compression was expanding compressed jpegs (thanks choward)

--- a/ebookmaker.conf
+++ b/ebookmaker.conf
@@ -30,5 +30,6 @@
 # proxies: None
 # xelatex: xelatex
 # mobigen: kindlegen  # can also be a path to Calibre's ebook-convert
+# mobilang: # converter to use for languages not supported by Kindlegen
 # groff: groff
 # rhyming_dict: None

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -493,6 +493,7 @@ def config():
             'proxies' : None,
             'xelatex' : 'xelatex',
             'mobigen' : 'kindlegen',
+            'mobilang': '',
             'groff'   : 'groff',
             'rhyming_dict': None,
             'timestamp': datetime.datetime.today().isoformat()[:19],

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -82,6 +82,15 @@ class Spider(object):
             debug("Requesting iterlinks for: %s ..." % url)
             for url, elem in parser.iterlinks():
 
+                if elem.get('rel') == 'nofollow':
+                    # remove link to content not followed
+                    elem.tag = 'span'
+                    elem.set('data-nofolllow-href', elem.get('href'))
+                    del elem.attrib['href']
+                    del elem.attrib['rel']
+                    warning('not followed: %s' % url)
+                    continue
+
                 new_attribs = parsers.ParserAttributes()
                 new_attribs.url = urllib.parse.urldefrag(url)[0]
                 new_attribs.referrer = parser.attribs.url

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.9.2'
+VERSION = '0.9.3'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -52,7 +52,10 @@ class Parser(ParserBase):
             return was, image
 
         def get_image_data(image, format_, quality='keep'):
+            """ Format is the output format, not necessarily the input format """
             buf = six.BytesIO()
+            if image.format != 'JPEG' and quality == 'keep':
+                quality = 90
             if format_ == 'png':
                 image.save(buf, 'png', optimize=True)
             else:

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -59,7 +59,13 @@ class Parser(ParserBase):
             if format_ == 'png':
                 image.save(buf, 'png', optimize=True)
             else:
-                image.save(buf, 'jpeg', quality=quality)
+                try:
+                    image.save(buf, 'jpeg', quality=quality)
+                except ValueError as e:
+                    if quality == 'keep' and 'quantization' in str(e):
+                        image.save(buf, 'jpeg', quality=90)
+                    else:
+                        raise e
             return buf.getvalue()
 
         new_parser = Parser()

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -27,6 +27,7 @@ class Parser(HTMLParserBase):
         self.src = self.attribs.url
         self.attribs.url = self.wrapper_url(self.attribs.url)
         self.attribs.orig_url = self.attribs.url
+        self.attribs.nonlinear = True
         if not self.attribs.title:
             self.attribs.title = 'linked image'
         self.xhtml = lxml.etree.fromstring(

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -471,7 +471,6 @@ class HTMLParserBase(ParserBase):
             return elem.get('id')
 
         toc = []
-        last_depth = 0
 
         for header in xpath(
                 xhtml,
@@ -506,12 +505,6 @@ class HTMLParserBase(ParserBase):
                     depth = int(header.tag[-1:])
                 except ValueError:
                     depth = 2 # avoid top level
-
-                # fix bogus header numberings
-                if depth > last_depth + 1:
-                    depth = last_depth + 1
-
-                last_depth = depth
 
                 #join consecutive headers
                 next = header.getnext()

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -453,6 +453,15 @@ class HTMLParserBase(ParserBase):
                 yield 'pgepubid%05d' % i
                 i += 1
 
+        def get_header_text(header):
+            """ clean header text """
+            text = gg.normalize(etree.tostring(header,
+                                               method="text",
+                                               encoding=six.text_type,
+                                               with_tail=False))
+
+            return header.get('title', text).strip()
+
         idg = id_generator()
 
         def get_id(elem):
@@ -473,12 +482,12 @@ class HTMLParserBase(ParserBase):
                 '//xhtml:p[contains (@class, "topic-title")]'
             ):
 
-            text = gg.normalize(etree.tostring(header,
-                                               method="text",
-                                               encoding=six.text_type,
-                                               with_tail=False))
+            previous = header.getprevious()
+            if previous is not None and previous.tag == header.tag:
+                # consecutive headers get combined
+                continue
 
-            text = header.get('title', text).strip()
+            text = get_header_text(header)
 
             if not text:
                 # so <h2 title=""> may be used to suppress TOC entry
@@ -504,6 +513,12 @@ class HTMLParserBase(ParserBase):
 
                 last_depth = depth
 
+                #join consecutive headers
+                next = header.getnext()
+                while next is not None and next.tag == header.tag:
+                    text = (text + ' ' + get_header_text(next)).strip()
+                    next = next.getnext()
+                    
                 # if <h*> is first element of a <div> use <div> instead
                 parent = header.getparent()
                 if (parent.tag == NS.xhtml.div and

--- a/ebookmaker/tests/test_setup.py
+++ b/ebookmaker/tests/test_setup.py
@@ -42,6 +42,9 @@ class TestLoad(unittest.TestCase):
         broken_parser.pre_parse()
         self.assertTrue(len(broken_parser.image_data) > 0)
         self.assertTrue(broken_parser.get_image_dimen()[0] > 0)
+        
+        # check conversion to jpeg
+        broken_parser.resize_image(16 * 1024, (66, 100), output_format='jpeg')
 
     def test_writers(self):
         WriterFactory.load_writers()

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -296,6 +296,8 @@ class OutlineFixer(object):
         self.last = 0
 
     def level(self, in_level):
+        if in_level < 1:
+            return in_level
         (promotion, from_level) = self.stack[-1]
         if in_level > self.last + 1:
             # needs promotion

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -86,7 +86,8 @@ body, body.tei.tei-text {
    }
 div, p, pre, h1, h2, h3, h4, h5, h6 {
    margin-left: 0;
-   margin-right: 0
+   margin-right: 0;
+   display: block
    }
 div.pgebub-root-div {
    margin: 0

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -542,7 +542,8 @@ class ContentOPF(object):
         """ Add item to spine and manifest from parser. """
         if hasattr(p.attribs, 'comment'):
             self.manifest.append(etree.Comment(p.attribs.comment))
-        return self.spine_item(p.attribs.url, p.mediatype(), p.attribs.id)
+        return self.spine_item(p.attribs.url, p.mediatype(), p.attribs.id,
+                               linear=not hasattr(p.attribs, 'nonlinear'))
 
 
     def toc_item(self, url):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.9.2'
+VERSION = '0.9.3'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
- Fix reversion in 0.9.2 which caused CoverWriter in EbookConverter to fail. (It uses ImageParser to convert images from PNG to JPEG
- also, add a test to check this