### PR TITLE
fix #75

### DIFF
--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -189,14 +189,20 @@ class Parser (HTMLParserBase):
     def _fix_anchors (self):
         """ Move name to id and fix hrefs and ids. """
 
+        def ids_and_names(xhtml):
+            """iterator that runs over id attributes and name attributes"""
+            for node in xpath (xhtml, "//xhtml:*[@id]"):
+                yield node
+            for node in xpath (xhtml, "//xhtml:a[@name]"):
+                yield node
+            
         # move anchor name to id
         # 'id' values are more strict than 'name' values
         # try to fix ill-formed ids
 
         seen_ids = set ()
 
-        for anchor in (xpath (self.xhtml, "//xhtml:a[@name]") +
-                       xpath (self.xhtml, "//xhtml:*[@id]")):
+        for anchor in ids_and_names(self.xhtml):
             id_ = anchor.get ('id') or anchor.get ('name')
 
             if 'name' in anchor.attrib:

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -27,7 +27,7 @@ from lxml.builder import ElementMaker
 import libgutenberg.GutenbergGlobals as gg
 from libgutenberg.GutenbergGlobals import NS, xpath
 from libgutenberg.MediaTypes import mediatypes as mt
-from libgutenberg.Logger import info, debug, error
+from libgutenberg.Logger import info, debug, warning, error
 
 from ebookmaker.CommonCode import Options
 
@@ -496,9 +496,12 @@ class HTMLParserBase(ParserBase):
                 toc.append(["%s#%s" % (self.attribs.url, get_id(header)), text, -1])
             else:
                 # header
-                if text.lower().startswith('by '):
+                if ((text.lower().startswith('by ')
+                     or text.lower() == ('by'))
+                    and 'x-ebookmaker-important' not in header.get('class', '')):
                     # common error in PG: <h2>by Lewis Carroll</h2> should
                     # yield no TOC entry
+                    warning('dropping by-heading in %s: %s', self.attribs.url, text.lower())
                     continue
 
                 try:

--- a/ebookmaker/tests/samples/43172/43172-h/43172-h.htm
+++ b/ebookmaker/tests/samples/43172/43172-h/43172-h.htm
@@ -174,14 +174,15 @@ CONFERENZA<br /><br />
 <span class="smcap x-large"><b>Cesare Lombroso</b></span>.
 </p>
 </div>
-
+<h3> by Cesare Lombroso</h3>
 <div class="chapter">
 <p>
 <span class="pagenum"><a id="Page_3"></a>[3]</span>
 </p>
 
-<h2>
-I.
+
+<h2 class="x-ebookmaker-important">
+by I.
 <br />
 <span class="smcap">Rivoluzione e Misoneismo.</span>
 </h2>


### PR DESCRIPTION
don't drop a heading that starts with "by " if class 'x-ebookmaker-important' is on it.
also log headings that are dropped because they start with "by "