### PR TITLE
Generated html

### DIFF
--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -416,20 +416,7 @@ def do_job(job):
     start_time = datetime.datetime.now()
     try:
         if job.url:
-            spider = Spider.Spider()
-            dirpath = os.path.dirname(job.url)  # platform native path
-            spider.include_urls += (options.include_urls or
-                                    [parsers.webify_url(dirpath) + '/*']) # use for parser only
-
-            spider.include_mediatypes += options.include_mediatypes
-            if job.subtype == '.images' or job.type == 'rst.gen':
-                spider.include_mediatypes.append('image/*')
-
-            spider.exclude_urls += options.exclude_urls
-
-            spider.exclude_mediatypes += options.exclude_mediatypes
-
-            spider.max_depth = options.max_depth or six.MAXSIZE
+            spider = Spider.Spider(job)
 
             for rewrite in options.rewrite:
                 from_url, to_url = rewrite.split('>')

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -123,7 +123,8 @@ class Spider(object):
                 tag = elem.tag
                 if tag == NS.xhtml.a:
                     if self.is_image(new_attribs) and self.is_included_url(new_attribs) and \
-                            self.is_included_mediatype(new_attribs):
+                            self.is_included_mediatype(new_attribs) and \
+                            self.jobtype in ('epub.images',):
                         # need to wrap an image
                         wrapper_parser = parsers.WrapperParser.Parser(new_attribs)
                         if wrapper_parser.attribs.url not in self.parsed_urls:

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -99,7 +99,7 @@ class Spider(object):
                 url = urllib.parse.urldefrag(url)[0]
                 if url == parser.attribs.url or url in self.parsed_urls:
                     continue
-                if elem.get('rel') == 'nofollow':
+                if elem.get('rel') == 'nofollow' and self.jobtype in ('epub.images',):
                     # remove link to content not followed
                     elem.tag = 'span'
                     elem.set('data-nofolllow-href', elem.get('href'))

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -13,7 +13,7 @@ Rudimentary Web Spider
 
 """
 
-
+import os.path
 import fnmatch
 
 from six.moves import urllib
@@ -24,22 +24,37 @@ from libgutenberg.Logger import debug, warning, error
 from libgutenberg import MediaTypes
 
 from ebookmaker import parsers
+from ebookmaker.CommonCode import Options
 from ebookmaker.ParserFactory import ParserFactory
 
+options = Options()
 
 class Spider(object):
     """ A very rudimentary web spider. """
 
-    def __init__(self):
+    def __init__(self, job):
         self.parsed_urls = set()
         self.parsers = []
         self.redirection_map = {}
 
+        dirpath = os.path.dirname(job.url)  # platform native path
+        # use for parser only
         self.include_urls = []
-        self.exclude_urls = []
+        self.include_urls += options.include_urls or [parsers.webify_url(dirpath) + '/*']
+
         self.include_mediatypes = []
+        self.include_mediatypes += options.include_mediatypes
+        if job.subtype == '.images' or job.type == 'rst.gen':
+            self.include_mediatypes.append('image/*')
+
+        self.exclude_urls = []
+        self.exclude_urls += options.exclude_urls
+
         self.exclude_mediatypes = []
-        self.max_depth = 1
+        self.exclude_mediatypes += options.exclude_mediatypes
+
+        self.max_depth = options.max_depth or six.MAXSIZE
+        self.jobtype = job.type
 
 
     def recursive_parse(self, root_attribs):

--- a/ebookmaker/parsers/CSSParser.py
+++ b/ebookmaker/parsers/CSSParser.py
@@ -57,7 +57,6 @@ class Parser (ParserBase):
                 return
             
         self.attribs.mediatype = parsers.ParserAttributes.HeaderElement ('text/css')
-        self.unpack_media_handheld (self.sheet)
         self.lowercase_selectors (self.sheet)
 
 
@@ -71,7 +70,6 @@ class Parser (ParserBase):
         self.sheet = parser.parseString (s)
 
         self.attribs.mediatype = parsers.ParserAttributes.HeaderElement ('text/css')
-        self.unpack_media_handheld (self.sheet)
         self.lowercase_selectors (self.sheet)
 
 
@@ -82,17 +80,6 @@ class Parser (ParserBase):
             if rule.type == rule.STYLE_RULE:
                 for prop in rule.style:
                     yield prop
-
-
-    @staticmethod
-    def unpack_media_handheld (sheet):
-        """ unpack a @media handheld rule """
-        for rule in sheet:
-            if rule.type == rule.MEDIA_RULE:
-                if rule.media.mediaText.find ('handheld') > -1:
-                    debug ("Unpacking CSS @media handheld rule.")
-                    rule.media.mediaText = 'all'
-                    rule.insertRule (cssutils.css.CSSComment ('/* was @media handheld */'), 0)
 
 
     @staticmethod

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -847,11 +847,19 @@ class Writer(writers.HTMLishWriter):
 
     @staticmethod
     def fix_incompatible_css(sheet):
-        """ Strip CSS properties and values that are not EPUB compatible. """
+        """ Strip CSS properties and values that are not EPUB compatible. 
+            Unpack "media handheld" rules
+        """
 
         cssclass = re.compile(r'\.(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)')
 
         for rule in sheet:
+            if rule.type == rule.MEDIA_RULE:
+                if rule.media.mediaText.find ('handheld') > -1:
+                    debug ("Unpacking CSS @media handheld rule.")
+                    rule.media.mediaText = 'all'
+                    info("replacing  @media handheld rule with @media all")
+
             if rule.type == rule.STYLE_RULE:
                 ruleclasses = list(cssclass.findall(rule.selectorList.selectorText))
                 for p in list(rule.style):


### PR DESCRIPTION
Ebookmaker was generating html only for rst and txt imput.
The following changes we made so that we could use generated html for all pg texts
1. Don't stop generating html with first html file.
2. Don't generate wrapper files when spidering to generate html
3. Move @media handling to EpubWriter, not in parser.
4. Also copy css and images to target directory
5. Don't rewrite urls on output; they're already relative
6. Let Spider follow "nofollow" links