### PR TITLE
use prober html, close sessions, emit html even in same directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,11 @@
 0.11.6 September 2, 2021
-- Using libgutenberg 0.8.7, which includes HTML5 style meta tags.
+- Using libgutenberg 0.8.7, which includes the type of meta tags used in HTML5.
 - Ebookmaker was not saving the derived HTML files if the main source file was in the output directory. This prevented online Ebookmaker to from displaying the files. Now, Ebookmaker will put derived files in an "out" directory. This turned out to require some code restructuring.
 - The pseudo-xhtml files produced by 0.11.5 were cause problems with browser compatibility, most noticeably by doubling break elements. It turns out that the quirky output from lxml was caused by xml namespacing of elements. when xml namespaces were removed, the html output method worked as desired, resulting in files that in many cases validated as html5. This solved a number of problems for us, and puts us in a position to start remediating problem files in the backfile in preparation for EPUB3.
 - The encoding for all python source files was changed to UTF8. A mis-encoded python file caused a problem with mdashes in titles.
 - Sessions are now closed after every set of jobs. Ebookconverter was running out of Databse connections.
 - Some superfluous logging was removed.
+- There is documentation for the changes introduced in version 0.11
 
 0.11.5 August 28, 2021
 - fix bug in stand-alone kindle generation

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.11.6 September 2, 2021
+0.11.7 September 2, 2021
 - Using libgutenberg 0.8.7, which includes the type of meta tags used in HTML5.
 - Ebookmaker was not saving the derived HTML files if the main source file was in the output directory. This prevented online Ebookmaker to from displaying the files. Now, Ebookmaker will put derived files in an "out" directory. This turned out to require some code restructuring.
 - The pseudo-xhtml files produced by 0.11.5 were cause problems with browser compatibility, most noticeably by doubling break elements. It turns out that the quirky output from lxml was caused by xml namespacing of elements. when xml namespaces were removed, the html output method worked as desired, resulting in files that in many cases validated as html5. This solved a number of problems for us, and puts us in a position to start remediating problem files in the backfile in preparation for EPUB3.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.11.6 September 2, 2021
+- Using libgutenberg 0.8.7, which includes HTML5 style meta tags.
+- Ebookmaker was not saving the derived HTML files if the main source file was in the output directory. This prevented online Ebookmaker to from displaying the files. Now, Ebookmaker will put derived files in an "out" directory. This turned out to require some code restructuring.
+- The pseudo-xhtml files produced by 0.11.5 were cause problems with browser compatibility, most noticeably by doubling break elements. It turns out that the quirky output from lxml was caused by xml namespacing of elements. when xml namespaces were removed, the html output method worked as desired, resulting in files that in many cases validated as html5. This solved a number of problems for us, and puts us in a position to start remediating problem files in the backfile in preparation for EPUB3.
+- The encoding for all python source files was changed to UTF8. A mis-encoded python file caused a problem with mdashes in titles.
+- Sessions are now closed after every set of jobs. Ebookconverter was running out of Databse connections.
+- Some superfluous logging was removed.
+
 0.11.5 August 28, 2021
 - fix bug in stand-alone kindle generation
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.11.8 September 2, 2021
+- fix crash when source document contains html comments
+
 0.11.7 September 2, 2021
 - Using libgutenberg 0.8.7, which includes the type of meta tags used in HTML5.
 - Ebookmaker was not saving the derived HTML files if the main source file was in the output directory. This prevented online Ebookmaker to from displaying the files. Now, Ebookmaker will put derived files in an "out" directory. This turned out to require some code restructuring.

--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,5 @@ pylint = "*"
 [packages]
 e1839a8 = {path = ".",editable = true}
 ebookmaker = {editable = true,path = "."}
-libgutenberg = "==0.8.6"
+libgutenberg = "==0.8.7"
 psycopg2 = "*"

--- a/docs/ebookmaker_v0_11.md
+++ b/docs/ebookmaker_v0_11.md
@@ -4,7 +4,9 @@ In addition to some small tweaks in its generated EPUBs, Ebookmaker version 0.11
 
 The source HTML files are not modified, and are available (at the URLs they've always been at) via the "More files..." link on the website. Errata should be addressed in the source files, not the derived files, as whitespace and link structure are changed by ebookmaker in ways that may preclude reprocessing. Files are re-derived for the entire catalog monthly.
 
-A major impetus for this change is to improve compatibility with browser plugins, mobile apps, proxy servers, accessibility tools and PG's own file processors. Much of our back file uses old versions of HTML that are poorly supported in modern browsers and other tools, and while there is ongoing work to update the back file, we are thousands of books away from being able to present uniformly coded HTML. This change is also a first step towards being able to use HTML5 for both source files and for presentation.
+A major impetus for this change is to improve compatibility with browser plugins, mobile apps, proxy servers, accessibility tools and PG's own file processors. Much of our back file uses old versions of HTML that are poorly supported in modern browsers and other tools, and while there is ongoing work to update the back file, we are thousands of books away from being able to present uniformly coded HTML. This change is also a first step towards being able to use HTML5 for both source files and for presentation; for many PG books, the derived files will validate as HTML5. 
+
+Submitters should be aware that our current process first converts submitted files to XHTML and HTML5ish files are derived from the XHTML; our process does not yet support features introduced in HTML5.
 
 Here are the differences between HTML source files and the HTML files derived from them:
 
@@ -13,15 +15,15 @@ Here are the differences between HTML source files and the HTML files derived fr
     ii. LF is used as the newline character for all files (unix standard)
     iii. HTML entities such as `&rsquo;` `&Aacute;` etc. are converted to unicode characters. Together with webserver configuration changes, this will improve web browser compatibility.
     iv. Tidy corrects badly formed HTML, improving browser compatibility and standards conformance.
-    v. A doctype declaration for XHTML+RDFa 1.1 is used for all files to allow better validation with included RDFa metadata.
+    v. An doctype declaration: `<!DOCTYPE html>` is used for all files This is compatible with the included metadata.
     vi. Tags are now uniformly lower case
     vii. Some legacy presentational tags (`<i>`, `<b>`, `<center>` when enclosed within appropriate inline tags, and ) are replaced with CSS `<style>` tags and structural markup as appropriate.
     viii. Empty paragraphs are discarded.
     ix. Any text directly in the `<body>` element is wrapped in a `<p>` element.
-    x. Self-closing tags are now closed with an end tag. So... `<a id="x" />` is changed to `<a id="x" ></a>`. This is needed because Chrome and Safari no longer support self-closing tags. The oddest looking change is `<br>` -> `<br></br>`. We need that because we're still using XHTML to support legacy content and EPUB2. We expect a lot of remediation work will be needed before we can switch to HTML5 and EPUB3.
+    x. Empty tags in HTML not closed with an end tag. So... `<a id="x" />` is changed to `<a id="x" ></a>`. This is needed because Chrome and Safari no longer support self-closing tags.
     xi. Inline style attributes are moved to a generated inline stylesheet for better rendering performance. The same mechanism is used to separate CSS from text in our EPUB files.
     
-2. Metadata is added to the `<head>` element. We include RDFa, Dublin Core, and schema.org metadata for better SEO and Facebook/Twitter unfurls. Changes in the metadata are now reflected in the HTML presentation.
+2. Metadata is added to the `<head>` element. We include Facebook OpenGraph, Dublin Core, and schema.org metadata for better SEO and Facebook/Twitter unfurls. Changes in the metadata entered by cataloguers are now reflected in the metadata of the HTML presentation.
 
 3. Because the derived HTML is moved to a new directory, linked files also needed to be moved. Because the derived file has a different name, back-links needed to be changed.
 

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -518,11 +518,12 @@ def main():
     WriterFactory.load_writers()
     PackagerFactory.load_packagers()
 
+    output_files = dict()
     if options.is_job_queue:
         job_queue = cPickle.load(sys.stdin.buffer) # read bytes
+
     else:
-        job_queue = []
-        output_files = dict()
+        job_queue = []        
         for type_ in options.types:
             job = CommonCode.Job(type_)
             job.url = options.url

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -530,6 +530,7 @@ def main():
             job.outputdir = options.outputdir
             job_queue.append(job)
 
+    dc = None
     for job in job_queue:
         dc = get_dc(job) # this is when doc at job.url gets parsed!
         job.outputfile = job.outputfile or options.outputfile or make_output_filename(job.type, dc)
@@ -543,6 +544,9 @@ def main():
         options.outputdir = job.outputdir
         job.dc = dc
         do_job(job)
+    else:
+        if dc and hasattr(dc, 'session') and dc.session:
+            dc.session.close()
 
     packager = PackagerFactory.create(options.packager, 'push')
     if packager:

--- a/ebookmaker/HTMLChunker.py
+++ b/ebookmaker/HTMLChunker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/ParserFactory.py
+++ b/ebookmaker/ParserFactory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.6'
+VERSION = '0.11.7'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.5'
+VERSION = '0.11.6'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.7'
+VERSION = '0.11.8'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/WriterFactory.py
+++ b/ebookmaker/WriterFactory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/packagers/__init__.py
+++ b/ebookmaker/packagers/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/AuxParser.py
+++ b/ebookmaker/parsers/AuxParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/CSSParser.py
+++ b/ebookmaker/parsers/CSSParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/GutenbergTextParser.py
+++ b/ebookmaker/parsers/GutenbergTextParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/WrapperParser.py
+++ b/ebookmaker/parsers/WrapperParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/parsers/__init__.py
+++ b/ebookmaker/parsers/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -108,12 +108,11 @@ class Writer(writers.HTMLishWriter):
         else:
             if url.startswith(webify_url(job.outputdir)):
                 relativeURL = gg.make_url_relative(webify_url(job.outputdir) + '/', url)
-                info ('output relativeURL for %s to %s : %s', webify_url(job.outputdir), url, relativeURL)
+                debug('output relativeURL for %s to %s : %s', webify_url(job.outputdir), url, relativeURL)
             else:
                 relativeURL = gg.make_url_relative(job.main, url)
-                info ('relativeURL for %s to %s : %s', job.main, url, relativeURL)
+                debug('relativeURL for %s to %s : %s', job.main, url, relativeURL)
 
-        info("source: %s relative: %s", url, relativeURL)
         return os.path.join(os.path.abspath(job.outputdir), relativeURL)
 
 
@@ -139,8 +138,7 @@ class Writer(writers.HTMLishWriter):
             outfile = gg.normalize_path(outfile)
 
             if gg.is_same_path(p.attribs.url, outfile):
-                #should never happen
-                error('%s is same as %s: should not overwrite source', p.attribs.url, outfile)
+                # debug('%s is same as %s: won't override source', p.attribs.url, outfile)
                 continue
 
             gg.mkdir_for_filename(outfile)

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -105,12 +105,8 @@ class Writer(writers.HTMLishWriter):
 
             outfile = self.outputfileurl(job, p.attribs.url)
 
-            if p.attribs.url.startswith(webify_url(job.outputdir)):
-                debug('%s is same as %s: already there'
-                      % (p.attribs.url, job.outputdir))
-                continue
             if gg.is_same_path(p.attribs.url, outfile):
-                debug('%s is same as %s: should not overwrite source'
+                warning('%s is same as %s: should not overwrite source'
                       % (p.attribs.url, outfile))
                 continue
 

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -171,7 +171,8 @@ class Writer(writers.HTMLishWriter):
                     # https://stackoverflow.com/questions/18159221/
                     html = copy.deepcopy(xhtml)
                     for elem in html.getiterator():
-                        elem.tag = etree.QName(elem).localname
+                        if elem.tag is not etree.Comment:
+                            elem.tag = etree.QName(elem).localname
                     # Remove unused namespace declarations
                     etree.cleanup_namespaces(html)
                     

--- a/ebookmaker/writers/KindleWriter.py
+++ b/ebookmaker/writers/KindleWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/writers/PicsDirWriter.py
+++ b/ebookmaker/writers/PicsDirWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/ebookmaker/writers/RSTWriter.py
+++ b/ebookmaker/writers/RSTWriter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 RSTWriter.py

--- a/ebookmaker/writers/__init__.py
+++ b/ebookmaker/writers/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/convert_unitame
+++ b/scripts/convert_unitame
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/ebookmaker
+++ b/scripts/ebookmaker
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/scripts/rhyme_compiler
+++ b/scripts/rhyme_compiler
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#  -*- mode: python; indent-tabs-mode: nil; -*- coding: iso-8859-1 -*-
+#  -*- mode: python; indent-tabs-mode: nil; -*- coding: UTF8 -*-
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.5'
+VERSION = '0.11.6'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.6'
+VERSION = '0.11.7'
 
 setup (
     name = 'ebookmaker',
@@ -43,7 +43,7 @@ setup (
         'roman',
         'requests',
         'six>=1.4.1',
-        'libgutenberg[covers]>=0.8.1',
+        'libgutenberg[covers]>=0.8.7',
     ],
     
     package_data = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.7'
+VERSION = '0.11.8'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
0.11.6 September 2, 2021
- Using libgutenberg 0.8.7, which includes the type of meta tags used in HTML5.
- Ebookmaker was not saving the derived HTML files if the main source file was in the output directory. This prevented online Ebookmaker to from displaying the files. Now, Ebookmaker will put derived files in an "out" directory. This turned out to require some code restructuring.
- The pseudo-xhtml files produced by 0.11.5 were cause problems with browser compatibility, most noticeably by doubling break elements. It turns out that the quirky output from lxml was caused by xml namespacing of elements. when xml namespaces were removed, the html output method worked as desired, resulting in files that in many cases validated as html5. This solved a number of problems for us, and puts us in a position to start remediating problem files in the backfile in preparation for EPUB3.
- The encoding for all python source files was changed to UTF8. A mis-encoded python file caused a problem with mdashes in titles.
- Sessions are now closed after every set of jobs. Ebookconverter was running out of Databse connections.
- Some superfluous logging was removed.
fixes #53, fixes #93