### PR TITLE
more html5 improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,16 @@
+0.11.12 September 30, 2021
+- fix reversion in 0.11.10 leaving out added meta elements
+- remove encoding meta element originating in HTML5 source from EPUB2 files, as it was causing validation failures.
+- remove @media handheld rules for HTML
+- move content of table summary attribute to data-summary attribute
+- width attribute on table and col is converted to css in a style attribute
+- non-integer width or height on img is converted to css in a style attribute
+- fixed epub builds for books with images in external css sheets
+- the 'big' element is obsolete; changed to <span class="xhtml_big">. css is altered or added as appropriate
+- a number of table attributes are obsolete an changed to the corresponding css styles: table@width, col@width, table@cellpadding, table@cellspacing, table@border, td@align, th@align, td@valign, th@valign
+- html5 doesn't allow elision of dd in dl. Where they are missing, we add empty dd
+
+
 0.11.11 September 22, 2021
 - remove encoding meta element originating in HTML5 source from EPUB2 files, as it was causing validation failures.
 - fix bug when an XHTML source file set an xml:lang attribute

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.11.11 September 22, 2021
+- remove encoding meta element originating in HTML5 source from EPUB2 files, as it was causing validation failures.
+- fix bug when an XHTML source file set an xml:lang attribute
+
+
 0.11.10 September 20, 2021
 - use tidy for _all_ html source files
 - addressed long-standing issue where images referenced in css were not included in epubs. This issue surfaced because the images were also missing from generated files.

--- a/CHANGES
+++ b/CHANGES
@@ -7,8 +7,14 @@
 - non-integer width or height on img is converted to css in a style attribute
 - fixed epub builds for books with images in external css sheets
 - the 'big' element is obsolete; changed to <span class="xhtml_big">. css is altered or added as appropriate
-- a number of table attributes are obsolete an changed to the corresponding css styles: table@width, col@width, table@cellpadding, table@cellspacing, table@border, td@align, th@align, td@valign, th@valign
+- a number of table attributes are obsolete in html5 and changed to the corresponding css styles: table@width, col@width, table@cellpadding, table@cellspacing, table@border, td@align, th@align, td@valign, th@valign
 - html5 doesn't allow elision of dd in dl. Where they are missing, we add empty dd
+- html5 doesn't permit carriage returns. these are replace by newlines when represented as numeric entities.
+- libgutenberg dependency updated to 0.8.11
+    - fix issue of polymorphism in dc.languages. Without a db, it's a list of structs; with a db, its a related collection.
+    - ebookmaker will no longer ignore xml:lang or DC meta attributes
+    - fix windows path comparison - ebookmaker will behave properly when input file is in outputdir
+
 
 
 0.11.11 September 22, 2021

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,15 @@
-0.11.8 September 3, 2021
+0.11.10 September 20, 2021
+- use tidy for _all_ html source files
+- addressed long-standing issue where images referenced in css were not included in epubs. This issue surfaced because the images were also missing from generated files.
+- addressed some simple issues preventing derived HTML5 files from validating. More complex issues involving incompatibilities between XHTML and HTML5 have been enumerated and will be addressed in subsequent updates.
+    - removed http-equiv meta elements for Content-Type and Content-Style-Type
+    - set lang attribute when xml:lang attribute is present
+    - removed duplicate encoding meta elements introduced by HTML5 source.
+    - removed type attribute from style elements
+- update requirements so that stand-alone installs will work better
+
+
+0.11.9 September 3, 2021
 - more aggressive session closing
 
 0.11.8 September 2, 2021

--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,5 @@ pylint = "*"
 [packages]
 e1839a8 = {path = ".",editable = true}
 ebookmaker = {editable = true,path = "."}
-libgutenberg = ">=0.8.9"
+libgutenberg = ">=0.8.10"
 psycopg2 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,5 @@ pylint = "*"
 [packages]
 e1839a8 = {path = ".",editable = true}
 ebookmaker = {editable = true,path = "."}
-libgutenberg = ">=0.8.10"
+libgutenberg = ">=0.8.11"
 psycopg2 = "*"

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -214,8 +214,8 @@ def get_dc(job):
 
     # We need a language to build a valid epub, so just make one up.
     if not dc.languages:
+        info('no language found, using default')
         dc.add_lang_id('en')
-
     return dc
 
 

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -138,7 +138,7 @@ class Spider(object):
                     else:
                         self.enqueue(queue, depth + 1, new_attribs, True)
                         
-                elif tag == NS.xhtml.img:
+                elif tag in (NS.xhtml.img, NS.xhtml.style):
                     self.enqueue(queue, depth, new_attribs, False)
                 elif tag == NS.xhtml.link:
                     if new_attribs.rel.intersection(('stylesheet', 'coverpage')):

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.10'
+VERSION = '0.11.11'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.11'
+VERSION = '0.11.12'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.9'
+VERSION = '0.11.10'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/parsers/CSSParser.py
+++ b/ebookmaker/parsers/CSSParser.py
@@ -113,7 +113,7 @@ class Parser(ParserBase):
         """ remove all rules with url() in them """
         to_delete = []
         for rule in self.sheet:
-            if rule.type == rule.STYLE_RULE and 'url(' in rule.cssText:
+            if rule.type == rule.STYLE_RULE and rule.cssText and 'url(' in rule.cssText:
                 to_delete.append(rule)
         for rule in to_delete:        
             self.sheet.deleteRule(rule)

--- a/ebookmaker/parsers/CSSParser.py
+++ b/ebookmaker/parsers/CSSParser.py
@@ -39,8 +39,7 @@ class Parser(ParserBase):
         ParserBase.__init__(self, attribs)
         self.sheet = None
 
-
-    def parse(self):
+    def pre_parse(self):
         """ Parse the CSS file. """
 
         if self.sheet is not None:
@@ -97,23 +96,12 @@ class Parser(ParserBase):
         cssutils.replaceUrls(self.sheet, f)
 
 
-    def get_image_urls(self):
-        """ Return the urls of all images in document.
+    def iterlinks(self):
+        """ Return the urls of all images in document."""
+        
+        for url in cssutils.getUrls(self.sheet):
+            yield urllib.parse.urljoin(self.attribs.url, url), parsers.em.style()
 
-        Images are graphic files. The user may choose if he wants
-        images included or not.
-
-        """
-
-        images = []
-
-        for prop in self.iter_properties(self.sheet):
-            if (prop.value.cssValueType == prop.value.CSS_PRIMITIVE_VALUE and
-                    prop.value.primitiveType == prop.value.CSS_URI):
-                url = urllib.parse.urljoin(self.attribs.url, prop.value.cssText)
-                images.append(url)
-
-        return  images
 
 
     def get_aux_urls(self):

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -411,17 +411,6 @@ class Parser(HTMLParserBase):
 
         html = self.unicode_content()
 
-        if html.startswith('<?xml'):
-            # Try a naive parse. This might fail because of errors in
-            # the html or because we have no dtd loaded.  We do not
-            # load dtds because that makes us dependent on network and
-            # the w3c site being up.  Having all users of ebookmaker
-            # install local dtds is unrealistic.
-            try:
-                self.xhtml = self.__parse(html)
-            except etree.ParseError:
-                pass
-
         if self.xhtml is None:
             # previous parse failed, try tidy
             info("Running html thru tidy.")

--- a/ebookmaker/parsers/HTMLParser.py
+++ b/ebookmaker/parsers/HTMLParser.py
@@ -410,6 +410,8 @@ class Parser(HTMLParserBase):
         debug("HTMLParser.pre_parse() ...")
 
         html = self.unicode_content()
+        html = html.replace('&#13;', '&#10;')
+        html = html.replace('&#xD;', '&#10;')
 
         if self.xhtml is None:
             # previous parse failed, try tidy

--- a/ebookmaker/tests/samples/43172/43172-h/43172-h.htm
+++ b/ebookmaker/tests/samples/43172/43172-h/43172-h.htm
@@ -62,6 +62,9 @@ div.footnotes {page-break-before: always; font-size: 90%; padding-top: 3em;}
 .poem p.i2 {text-indent: -1em;}
 .poem p.i6 {text-indent: 6em;}
 .punti {letter-spacing: 1em;}
+@media handheld {
+	big { font-size: 18pt;}
+}
 
     </style>
   </head>

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -1376,6 +1376,8 @@ class Writer(writers.HTMLishWriter):
                     p.parse()
                 if hasattr(p, 'sheet') and p.sheet:
                     self.fix_incompatible_css(p.sheet)
+                    if job.subtype == '.noimages':
+                        p.strip_images()
                     p.rewrite_links(self.url2filename)
                     parserlist.append(p)
 

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -946,6 +946,16 @@ class Writer(writers.HTMLishWriter):
             q.tag = "span"
             surround(q, '“', '”')
 
+    @staticmethod
+    def fix_html5(xhtml):
+        """
+        Find html5 constructs and tries to fix them for xhtml
+        """
+        for meta in xpath(xhtml, '//xhtml:meta[@charset]'):
+            meta.getparent().remove(meta)
+
+        
+
 
     @staticmethod
     def strip_links(xhtml, manifest):
@@ -1307,6 +1317,8 @@ class Writer(writers.HTMLishWriter):
                         p.parse()
                         xhtml = copy.deepcopy(p.xhtml) if hasattr(p, 'xhtml') else None
                     if xhtml is not None:
+                        self.fix_html5(xhtml)
+                        
                         strip_classes = self.get_classes_that_float(xhtml)
                         strip_classes = strip_classes.intersection(STRIP_CLASSES)
                         if strip_classes:

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -185,8 +185,6 @@ class Writer(writers.HTMLishWriter):
                     html = copy.deepcopy(xhtml)
                     if xmllang in html.attrib:
                         lang =  html.attrib[xmllang]
-                        if lang not in  job.dc.languages:
-                            job.dc.add_lang_id(lang)
                         html.attrib['lang'] = lang
                         del(html.attrib[xmllang])
                     self.add_dublincore(job, xhtml)

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -187,12 +187,12 @@ class Writer(writers.HTMLishWriter):
                         lang =  html.attrib[xmllang]
                         html.attrib['lang'] = lang
                         del(html.attrib[xmllang])
-                    self.add_dublincore(job, xhtml)
+                    self.add_dublincore(job, html)
 
                     # makes iphones zoom in
-                    self.add_meta(xhtml, 'viewport', 'width=device-width')
-                    self.add_meta_generator(xhtml)
-                    self.add_moremeta(job, xhtml, p.attribs.url)
+                    self.add_meta(html, 'viewport', 'width=device-width')
+                    self.add_meta_generator(html)
+                    self.add_moremeta(job, html, p.attribs.url)
                     
                     # strip xhtml namespace 
                     # https://stackoverflow.com/questions/18159221/

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -81,6 +81,7 @@ class Writer(writers.HTMLishWriter):
             job.main = url
             
             # check that the source file is not in the outputdir 
+            info("are these the same path? %s, %s", os.path.abspath(job.outputdir), os.path.dirname(url))
             if gg.is_same_path(os.path.abspath(job.outputdir), os.path.dirname(url)):
                 # make sure that source is not in an 'out" directory
                 newdir = 'out'
@@ -169,17 +170,12 @@ class Writer(writers.HTMLishWriter):
                     
                     # strip xhtml namespace 
                     # https://stackoverflow.com/questions/18159221/
-                    html = copy.deepcopy(xhtml)
                     for elem in html.getiterator():
                         if elem.tag is not etree.Comment:
                             elem.tag = etree.QName(elem).localname
                     # Remove unused namespace declarations
                     etree.cleanup_namespaces(html)
                     
-                    xmllang = '{http://www.w3.org/XML/1998/namespace}lang'
-                    if xmllang in html.attrib:
-                        html.attrib['lang'] = html.attrib[xmllang]
-                        del(html.attrib[xmllang])
                     html.head.insert(0, etree.Element('meta', charset="utf-8"))
 
                     html = etree.tostring(html,

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -15,9 +15,11 @@ Distributable under the GNU General Public License Version 3 or newer.
 import copy
 import os
 from pathlib import Path
+import re
 from urllib.parse import urlparse, urljoin
 import uuid
 
+import cssutils
 from lxml import etree
 
 import libgutenberg.GutenbergGlobals as gg
@@ -31,6 +33,17 @@ from ebookmaker.parsers import webify_url
 
 options = Options()
 XMLLANG = '{http://www.w3.org/XML/1998/namespace}lang'
+DEPRECATED = ['big']
+CSS_FOR_DEPRECATED = {
+    'big' : ".xhtml_big {font-size: larger;};"
+}
+
+def css_len(len_str):
+    """ if an int, make px """
+    try:
+        return str(int(len_str)) + 'px'
+    except ValueError:
+        return len_str
 
 class Writer(writers.HTMLishWriter):
     """ Class for writing HTML files. """
@@ -116,11 +129,45 @@ class Writer(writers.HTMLishWriter):
 
         return os.path.join(os.path.abspath(job.outputdir), relativeURL)
 
+
+    @staticmethod
+    def fix_incompatible_css(sheet):
+        """ Strip CSS properties and values that are not HTML5 compatible.
+            Unpack "media handheld" rules
+        """
+
+        cssclass = re.compile(r'\.(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)')
+
+        for rule in sheet:
+            if rule.type == rule.MEDIA_RULE:
+                if rule.media.mediaText.find('handheld') > -1:
+                    rule.parentStyleSheet.deleteRule(rule)
+
+            if rule.type == rule.STYLE_RULE:
+                ruleclasses = list(cssclass.findall(rule.selectorList.selectorText))
+                for p in list(rule.style):
+                    pass
+
+    def fix_css_for_deprecated(self, sheet, tags=DEPRECATED, replacement='span'):
+        """ for deprecated properties, change selector to {replacement}.xhtl_{tag name};
+            if no existing selector, add the selector with a style
+        """
+        for tag in tags:
+            tagre = re.compile(f'(^| |\\+|,|>|~){tag}')
+            tagsub = f'\\1{replacement}.xhtml_{tag}'
+            for rule in sheet:
+                if rule.type == rule.STYLE_RULE:
+                    for selector in rule.selectorList:
+                        selector.selectorText = tagre.sub(tagsub, selector.selectorText)
+                            
+
     def xhtml_to_html(self, html):
         ''' 
         try to convert the html4 DOM to an html5 DOM 
         (assumes xhtml namespaces have been removed, except from attribute values)
         '''
+
+        # fix metas 
         for meta in html.xpath("//meta[@http-equiv='Content-Type']"):
             meta.getparent().remove(meta)
         for meta in html.xpath("//meta[@http-equiv='Content-Style-Type']"):
@@ -129,13 +176,90 @@ class Writer(writers.HTMLishWriter):
             meta.getparent().remove(meta)
         for elem in html.xpath("//*[@xml:lang]"):
             if XMLLANG in elem.attrib: # should always be true, but checking anyway
-                elem.attrib['lang'] = elem.attrib[XMLLANG]
+                elem.set('lang', elem.attrib[XMLLANG])
             else:
-                 warning('XMLLANG expected, not found: %s@%s', elem.tag, elem.attrib)
+                warning('XMLLANG expected, not found: %s@%s', elem.tag, elem.attrib)
+
+        # remove type on style elements
         for style in html.xpath("//style[@type]"):
             del style.attrib['type']
-        html.head.insert(0, etree.Element('meta', charset="utf-8"))
 
+
+        # replacing attributes with css in a style attribute
+        # (tag, attr, cssprop, val2css)
+        replacements = [
+            ('col', 'width', 'width', css_len),
+            ('table', 'width', 'width', css_len),
+            ('td', 'align', 'text-align', lambda x : x),
+            ('td', 'valign', 'vertical-align', lambda x : x),
+            ('th', 'align', 'text-align', lambda x : x),
+            ('th', 'valign', 'vertical-align', lambda x : x),
+            ('table', 'cellpadding', 'padding', css_len),
+            ('table', 'cellspacing', 'border-spacing', css_len),
+            ('table', 'border', 'border-width', css_len),
+        ]
+        # width obsolete on table, col
+        for (tag, attr, cssattr, val2css) in replacements:
+            for elem in html.xpath(f"//{tag}[@{attr}]"):
+                if elem.attrib[attr]:
+                    val = elem.attrib[attr]
+                    del elem.attrib[attr]
+                    elem.set('style',
+                             '%s: %s; %s' % (cssattr, val2css(val), elem.attrib.get('style', ''))
+                            )
+        
+        # width and height attributes must be integer
+        for elem in html.xpath("//*[@width or @height]"):
+            rules = []
+            for key in ['width', 'height']:
+                if key in elem.attrib and elem.attrib[key]:
+                    val = elem.attrib[key]
+                    try: 
+                        val = int(val)
+                    except ValueError:
+                        del elem.attrib[key]
+                        rules.append('%s: %s' % (key, val))
+            if rules:
+                elem.attrib['style'] = '; '.join(rules) + '; ' + elem.attrib.get('style', '')
+
+        # fix missing <dd> elements
+        for dt in html.xpath("//dt"):
+            if dt.getnext() is None or dt.getnext().tag != 'dd':
+                dt.addnext(etree.Element('dd'))
+            
+        # deprecated elements -  replace with <span class="xhtml_{tag name}">
+        deprecated = ['big']
+        deprecated_used = set()
+        for tag in deprecated:
+            for elem in html.xpath("//" + tag):
+                if 'class' in elem.attrib and elem.attrib['class']:
+                    vals = elem.attrib['class'].split()
+                else:
+                    vals = []
+                vals.append('xhtml_' + tag)
+                elem.set('class', ' '.join(vals))
+                elem.tag = 'span'
+                deprecated_used.add(tag)
+        
+        html.head.insert(0, etree.Element('meta', charset="utf-8"))
+        for table in html.xpath("//table"):
+            if 'summary' in table.attrib:
+                summary = table.attrib['summary']
+                del table.attrib['summary']
+                if summary:
+                    table.attrib['data-summary'] = summary
+
+        # fix css in style elements
+        cssparser = cssutils.CSSParser()
+        for style in html.xpath("//style"):
+            sheet = cssparser.parseString(style.text)
+            self.fix_incompatible_css(sheet)
+            self.fix_css_for_deprecated(sheet, tags=deprecated_used)
+            style.text = sheet.cssText
+
+        css_for_deprecated = ' '.join([CSS_FOR_DEPRECATED.get(tag, '') for tag in deprecated_used])
+        html.head.insert(0, etree.Element('style', text=css_for_deprecated))
+        
 
     def build(self, job):
         """ Build HTML file. """
@@ -185,7 +309,7 @@ class Writer(writers.HTMLishWriter):
                     html = copy.deepcopy(xhtml)
                     if xmllang in html.attrib:
                         lang =  html.attrib[xmllang]
-                        html.attrib['lang'] = lang
+                        html.attrib['lang'] = job.dc.languages[0].id or lang
                         del(html.attrib[xmllang])
                     self.add_dublincore(job, html)
 
@@ -213,6 +337,10 @@ class Writer(writers.HTMLishWriter):
                     info("Done generating HTML file: %s" % outfile)
                 else:
                     #images and css files
+
+                    if hasattr(p, 'sheet') and p.sheet:
+                        self.fix_incompatible_css(p.sheet)
+
                     try:
                         with open(outfile, 'wb') as fp_dest:
                             fp_dest.write(p.serialize())

--- a/ebookmaker/writers/__init__.py
+++ b/ebookmaker/writers/__init__.py
@@ -143,6 +143,7 @@ class HTMLishWriter(BaseWriter):
             attribs.url = attribs.orig_url = url
             p = ParserFactory.ParserFactory.get(attribs)
             p.parse_string(css_as_string)
+            p.make_links_absolute()
             spider.parsers.append(p)
 
         if xhtml is not None:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.11'
+VERSION = '0.11.12'
 
 setup (
     name = 'ebookmaker',
@@ -43,7 +43,7 @@ setup (
         'roman',
         'requests',
         'six>=1.4.1',
-        'libgutenberg[covers]>=0.8.10',
+        'libgutenberg[covers]>=0.8.11',
     ],
     
     package_data = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.9'
+VERSION = '0.11.10'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.10'
+VERSION = '0.11.11'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup (
         'roman',
         'requests',
         'six>=1.4.1',
-        'libgutenberg[covers]>=0.8.7',
+        'libgutenberg[covers]>=0.8.10',
     ],
     
     package_data = {


### PR DESCRIPTION
0.11.12 September 30, 2021
- fix reversion in 0.11.10 leaving out added meta elements
- remove encoding meta element originating in HTML5 source from EPUB2 files, as it was causing validation failures.
- remove @media handheld rules for HTML
- move content of table summary attribute to data-summary attribute
- width attribute on table and col is converted to css in a style attribute
- non-integer width or height on img is converted to css in a style attribute
- fixed epub builds for books with images in external css sheets
- the 'big' element is obsolete; changed to <span class="xhtml_big">. css is altered or added as appropriate
- a number of table attributes are obsolete in html5 and changed to the corresponding css styles: table@width, col@width, table@cellpadding, table@cellspacing, table@border, td@align, th@align, td@valign, th@valign
- html5 doesn't allow elision of dd in dl. Where they are missing, we add empty dd
- html5 doesn't permit carriage returns. these are replace by newlines when represented as numeric entities.
- libgutenberg dependency updated to 0.8.11
    - fix issue of polymorphism in dc.languages. Without a db, it's a list of structs; with a db, its a related collection.
    - ebookmaker will no longer ignore xml:lang or DC meta attributes
    - fix windows path comparison - ebookmaker will behave properly when input file is in outputdir
