### PR TITLE
docutils compatibility, --output-file, other bugfixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+0.11.28 November 24, 2021
+- fix #100. the behavior of --output-file has changed. a string passed using this argument is used to name the file where the Gutenberg ID would be. Previously it would be just the name of the output file, no matter the file type, except for Kindle, PDF and TeX. File naming for kindle was broken completely. In the past (version <0.11) --title would override the parsed or looked-up title. Title would be used in the file name if there was no Gutenberg id, or --outputfile.  
+- docutils rst conversion introduced a typo in 0.18 resulting in some css problems
+- added exception handling in ImageParser for broken images
+- don't select cover until it's needed. Ebookmaker has been generating unneeded covers in the txt step because it hasn't parsed an html file.
+- for HTML5, fixed a css syntax error in the css added for the table@cols attribute
+- for HTML5, make sure lang and xml:lang attributes are in sync; put invalid langs in data-invalid-lang attribute.
+- for HTML5, remove height or width attributes that are 0 or empty
+
+
 0.11.27 November 18, 2021
 - one more fix for docutils 0.18+
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.11.27 November 18, 2021
+- one more fix for docutils 0.18+
+
 0.11.26 November 11, 2021
 - fixed a problem with covers selected from linked images based on the file name. (The image file would be added twice).
 - fixed a problem with linked images being omitted if they also were used as the cover image

--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,4 @@ e1839a8 = {path = ".",editable = true}
 ebookmaker = {editable = true,path = "."}
 libgutenberg = ">=0.8.12"
 psycopg2 = "*"
+docutils = ">=0.18.1"

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -472,7 +472,8 @@ def do_job(job):
                     options.input_mediatype)
 
             spider.recursive_parse(attribs)
-            elect_coverpage(spider, job.url, job.dc)
+            if job.type.split('.')[0] in ('epub', 'html', 'kindle', 'cover'):
+                elect_coverpage(spider, job.url, job.dc)
             job.url = spider.redirect(job.url)
             job.base_url = job.url
             job.spider = spider

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -472,7 +472,7 @@ def do_job(job):
                     options.input_mediatype)
 
             spider.recursive_parse(attribs)
-            if job.type.split('.')[0] in ('epub', 'html', 'kindle', 'cover'):
+            if job.type.split('.')[0] in ('epub', 'html', 'kindle', 'cover', 'pdf'):
                 elect_coverpage(spider, job.url, job.dc)
             job.url = spider.redirect(job.url)
             job.base_url = job.url

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -105,10 +105,10 @@ COVERPAGE_MIN_AREA = 200 * 200
 
 def make_output_filename(type_, dc):
     """ Make a suitable filename for output type. """
-
-    if dc.project_gutenberg_id:
+    name_token = options.outputfile or dc.project_gutenberg_id
+    if name_token:
         # PG book: use PG naming convention
-        return FILENAMES[type_].format(id=dc.project_gutenberg_id)
+        return FILENAMES[type_].format(id=name_token)
     # not a PG ebook
     return FILENAMES[type_].format(id=gg.string_to_filename(dc.title)[:65])
 
@@ -371,7 +371,7 @@ def add_local_options(ap):
         metavar="OUTPUT_FILE",
         dest="outputfile",
         default=None,
-        help="output file (default: <title>.epub)")
+        help="token for use in filenames (default: <ebook number>)")
 
     ap.add_argument(
         "--validate",
@@ -568,7 +568,7 @@ def main():
     dc = None
     for job in job_queue:
         dc = get_dc(job) # this is when doc at job.url gets parsed!
-        job.outputfile = job.outputfile or options.outputfile or make_output_filename(job.type, dc)
+        job.outputfile = job.outputfile or make_output_filename(job.type, dc)
         output_files[job.type] = job.outputfile
         if job.type.startswith('kindle'):
             absoutputdir = os.path.abspath(job.outputdir)

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.27'
+VERSION = '0.11.28'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.26'
+VERSION = '0.11.27'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/mydocutils/transforms/parts.py
+++ b/ebookmaker/mydocutils/transforms/parts.py
@@ -504,7 +504,7 @@ class DropCapTransform (docutils.transforms.Transform):
 
         if len (iter_):
             para = iter_[0]
-            iter_ = para.traverse (nodes.Text)
+            iter_ = list (para.traverse (nodes.Text))
             details = self.startnode.details
 
             if len (iter_):

--- a/ebookmaker/mydocutils/transforms/parts.py
+++ b/ebookmaker/mydocutils/transforms/parts.py
@@ -500,7 +500,7 @@ class DropCapTransform (docutils.transforms.Transform):
     default_priority = 719 # run before Contents Transform
 
     def apply (self, **kwargs):
-        iter_ = self.startnode.traverse (nodes.paragraph, siblings = 1)
+        iter_ = list (self.startnode.traverse (nodes.paragraph, siblings = 1))
 
         if len (iter_):
             para = iter_[0]
@@ -618,12 +618,12 @@ class StyleTransform (docutils.transforms.Transform):
                 # placed before the title node.
 
                 # traverse all children of parent
-                node_list = pending.parent.traverse (
-                    mynodes.node_selector (selector), include_self = 0)
+                node_list = list (pending.parent.traverse (
+                    mynodes.node_selector (selector), include_self = 0))
             else:
                 # traverse all following nodes and their children
-                node_list = pending.traverse (
-                    mynodes.node_selector (selector), siblings = 1, include_self = 0)
+                node_list = list (pending.traverse (
+                    mynodes.node_selector (selector), siblings = 1, include_self = 0))
 
         # classes    = frozenset ([c for c in details.get ('class', []) if not c.startswith ('-')])
         # rmclasses  = frozenset ([c[1:] for c in details.get ('class', []) if c.startswith ('-')])

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -140,9 +140,10 @@ class Parser(ParserBase):
             if self.image_data:
                 try:
                     image = Image.open(six.BytesIO(self.image_data))
+                    self.dimen = image.size
                 except IOError as what:
                     error("Could not resize image (probably broken): %s", self.attribs.url)
-                self.dimen = (0, 0)  # broken image
+                    self.dimen = (0, 0)  # broken image
             else:
                 self.dimen = (0, 0)  # broken image
         return self.dimen

--- a/ebookmaker/parsers/ImageParser.py
+++ b/ebookmaker/parsers/ImageParser.py
@@ -126,7 +126,7 @@ class Parser(ParserBase):
             new_parser.fp = self.fp
 
         except IOError as what:
-            error("Could not resize image: %s" % what)
+            error("Could not resize image: %s", self.attribs.url)
             new_parser.attribs = copy.copy(self.attribs)
             fp = resource_stream('ebookmaker.parsers', 'broken.png')
             new_parser.image_data = fp.read()
@@ -138,8 +138,11 @@ class Parser(ParserBase):
     def get_image_dimen(self):
         if self.dimen is None:
             if self.image_data:
-                image = Image.open(six.BytesIO(self.image_data))
-                self.dimen = image.size
+                try:
+                    image = Image.open(six.BytesIO(self.image_data))
+                except IOError as what:
+                    error("Could not resize image (probably broken): %s", self.attribs.url)
+                self.dimen = (0, 0)  # broken image
             else:
                 self.dimen = (0, 0)  # broken image
         return self.dimen

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -57,7 +57,7 @@ border-width: thin;
 border-style: solid;}''',
     'cols': '''
 .rules-cols > tr > td, .rules-cols > * > tr > td,
-.rules-cols > tr > th, .rules-cols > * > tr > th' {
+.rules-cols > tr > th, .rules-cols > * > tr > th {
 border-left-width: thin;
 border-right-width: thin;
 border-left-style: solid;
@@ -109,9 +109,8 @@ def add_class(elem, classname):
 def add_style(elem, style=''):
     if style:
         if 'style' in elem.attrib and elem.attrib['style']:
-            style = style.strip()
-            style = style if style.endswith(';') else style + '; '
-            style = style + elem.attrib['style']
+            prev_style = elem.attrib['style'].strip(' ;')
+            style = f'{prev_style};{style.strip(" ;")};'
         elem.set('style', style)
 
 class Writer(writers.HTMLishWriter):

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -281,6 +281,11 @@ class Writer(writers.HTMLishWriter):
             for elem in html.xpath(f"//{tag}[not(@{attr})]"):
                 elem.set(attr, fill)
 
+        # remove not_empty attributes
+        nullattrs_to_remove = ['height', 'width']
+        for attr in nullattrs_to_remove:
+            for elem in html.xpath(f"//*[@{attr}='' or @{attr}=0]"):
+                del elem.attrib[attr]
 
         # replacing attributes with css in a style attribute
         # (tag, attr, cssprop, val2css)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup (
         'chardet',
         'cherrypy',
         'cssutils',
-        'docutils>=0.18',
+        'docutils>=0.18.1',
         'lxml',
         'roman',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.27'
+VERSION = '0.11.28'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.26'
+VERSION = '0.11.27'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
0.11.28 November 24, 2021
- fix #100. the behavior of --output-file has changed. a string passed using this argument is used to name the file where the Gutenberg ID would be. Previously it would be just the name of the output file, no matter the file type, except for Kindle, PDF and TeX. File naming for kindle was broken completely. In the past (version <0.11) --title would override the parsed or looked-up title. Title would be used in the file name if there was no Gutenberg id, or --outputfile.  
- docutils rst conversion introduced a typo in 0.18 resulting in some css problems
- added exception handling in ImageParser for broken images
- don't select cover until it's needed. Ebookmaker has been generating unneeded covers in the txt step because it hasn't parsed an html file.
- for HTML5, fixed a css syntax error in the css added for the table@cols attribute
- for HTML5, make sure lang and xml:lang attributes are in sync; put invalid langs in data-invalid-lang attribute.
- for HTML5, remove height or width attributes that are 0 or empty

0.11.27 November 18, 2021
- one more fix for docutils 0.18+

