### PR TITLE
down-convert html5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+0.11.29 November 30, 2021
+- for HTML5, remove Content-Language metas
+- when converting a presentational attribute to css in a style attribute, put the added css *before* existing content of the style, so as not to override it. this mimics browser behavior for cases when the two styles conflict. This won't do much good right away because tidy strips the styles into named classes.
+- stop adding a viewport meta tag. it turns out this interferes with good HTML5 designs for mobile.
+
+
 0.11.28 November 24, 2021
 - fix #100. the behavior of --output-file has changed. a string passed using this argument is used to name the file where the Gutenberg ID would be. Previously it would be just the name of the output file, no matter the file type, except for Kindle, PDF and TeX. File naming for kindle was broken completely. In the past (version <0.11) --title would override the parsed or looked-up title. Title would be used in the file name if there was no Gutenberg id, or --outputfile.  
 - docutils rst conversion introduced a typo in 0.18 resulting in some css problems

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,18 @@
+0.11.30 December 10, 2021
+- for EPUB, down-convert HTML5 tags to divs so the the files validate as EPUB2. The new div elements will add a class named the same as the html5 tag, so `<section>` becomes `<div class="section">`. Other attributes are preserved. In addition CSS selectors involving these elements will be transformed accordingly: for example `section` becomes `div.section`
+    - section
+    - figure  (initial style set to "margin: 1em 40px;",  copying from Firefox internal stylesheet.)
+    - figcaption
+    - header
+    - footer
+Users of these new tags need to check that their CSS does not conflict with the added classes or changed CSS. In almost all cases, avoiding HTML5 element names for CSS classes will prevent any conflict.
+- for EPUB, move 'tfoot' elements to before 'tbody' (the order used in HTML4)
+- for EPUB, remove any 'meta' elements using the 'property' attribute.
+- add 'CRITICAL' notification for 'too-deep' errors
+- reset parsers after txt jobs. fixes a bug when the text source file is linked from the html.
+- EPUBCheck validation was broken. To use EPUBCheck validation, first download and install EPUBCheck from https://www.w3.org/publishing/epubcheck/. If the command to invoke it is  `java -jar /Applications/epubcheck-4.2.6/epubcheck.jar`, then add this line to ~/.ebookmaker or /etc/ebookmaker.conf: `epub_validator: java -jar /Applications/epubcheck-4.2.6/epubcheck.jar` then turn on validation by adding `--validate` to Ebookmaker's command line invocation or by setting validate to true in ~/.ebookmaker
+
+
 0.11.29 November 30, 2021
 - for HTML5, remove Content-Language metas
 - when converting a presentational attribute to css in a style attribute, put the added css *before* existing content of the style, so as not to override it. this mimics browser behavior for cases when the two styles conflict. This won't do much good right away because tidy strips the styles into named classes.

--- a/ebookmaker/EbookMaker.py
+++ b/ebookmaker/EbookMaker.py
@@ -492,6 +492,10 @@ def do_job(job):
             # FIXME: hack for push packager
             options.html_images_list = list(job.spider.aux_file_iter())
 
+        if job.type.split('.')[0] == 'txt':
+            # don't us GutenbergTextParser for subsequent builds
+            ParserFactory.ParserFactory.parsers = {}
+
     except SkipOutputFormat as what:
         warning("%s" % what)
 

--- a/ebookmaker/Spider.py
+++ b/ebookmaker/Spider.py
@@ -174,7 +174,7 @@ class Spider(object):
                 warning('External link in %s: %s' % (attribs.referrer, attribs.url))
                 return
             if depth >= self.max_depth:
-                error('Omitted file %s due to depth > max_depth' % attribs.url)
+                critical('Omitted file %s due to depth > max_depth' % attribs.url)
                 return
         if not self.is_included_mediatype(attribs) and not self.is_included_relation(attribs):
             return

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.29'
+VERSION = '0.11.30'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/Version.py
+++ b/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.11.28'
+VERSION = '0.11.29'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -964,6 +964,12 @@ class Writer(writers.HTMLishWriter):
         for meta in xpath(xhtml, '//xhtml:meta[@property]'):
             meta.getparent().remove(meta)
 
+        # html5 moved tfoot to end of the table
+        for tfoot in xpath(xhtml, '//xhtml:*[last()][name()="tfoot"]'):
+            tbody = tfoot.getparent().find('{*}tbody')
+            if tbody is not None:
+                tbody.addprevious(tfoot)
+
         usedtags = set()
         for newtag in ['figcaption', 'figure', 'footer', 'header', 'section']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -961,6 +961,9 @@ class Writer(writers.HTMLishWriter):
         for meta in xpath(xhtml, '//xhtml:meta[@charset]'):
             meta.getparent().remove(meta)
 
+        for meta in xpath(xhtml, '//xhtml:meta[@property]'):
+            meta.getparent().remove(meta)
+
         usedtags = set()
         for newtag in ['figcaption', 'figure', 'footer', 'header', 'section']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):

--- a/ebookmaker/writers/EpubWriter.py
+++ b/ebookmaker/writers/EpubWriter.py
@@ -1221,22 +1221,21 @@ class Writer(writers.HTMLishWriter):
 
         filename = os.path.join(os.path.abspath(job.outputdir), job.outputfile)
 
-        for validator in (options.config.EPUB_VALIDATOR, options.config.EPUB_PREFLIGHT):
-            if validator is not None:
-                params = validator.split() + [filename]
-                checker = subprocess.Popen(params,
-                                           stdin=subprocess.PIPE,
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
+        if hasattr(options.config,'EPUB_VALIDATOR'):
+            validator = options.config.EPUB_VALIDATOR 
+            info('validating...')
+            params = validator.split() + [filename]
+            checker = subprocess.Popen(params,
+                                       stdin=subprocess.PIPE,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
 
-                (dummy_stdout, stderr) = checker.communicate()
-                if stderr:
-                    error(stderr)
-                    return 1
-                    #raise Assertionerror(
-                    #    "%s does not validate." % job.outputfile)
+            (dummy_stdout, stderr) = checker.communicate()
+            if stderr:
+                error(stderr)
+                return 1
 
-        debug("%s validates ok." % job.outputfile)
+        info("%s validates ok." % job.outputfile)
         return 0
 
 

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -110,7 +110,7 @@ def add_style(elem, style=''):
     if style:
         if 'style' in elem.attrib and elem.attrib['style']:
             prev_style = elem.attrib['style'].strip(' ;')
-            style = f'{prev_style};{style.strip(" ;")};'
+            style = f'{style.strip(" ;")};{prev_style};'
         elem.set('style', style)
 
 class Writer(writers.HTMLishWriter):

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -459,8 +459,6 @@ class Writer(writers.HTMLishWriter):
                         del(html.attrib[xmllang])
                     self.add_dublincore(job, html)
 
-                    # makes iphones zoom in
-                    self.add_meta(html, 'viewport', 'width=device-width')
                     self.add_meta_generator(html)
                     self.add_moremeta(job, html, p.attribs.url)
 

--- a/ebookmaker/writers/HTMLWriter.py
+++ b/ebookmaker/writers/HTMLWriter.py
@@ -255,6 +255,8 @@ class Writer(writers.HTMLishWriter):
             meta.getparent().remove(meta)
         for meta in html.xpath("//meta[translate(@http-equiv, 'CST', 'cst')='content-style-type']"):
             meta.getparent().remove(meta)
+        for meta in html.xpath("//meta[translate(@http-equiv, 'CL', 'cl')='content-language']"):
+            meta.getparent().remove(meta)
         for meta in html.xpath("//meta[@charset]"): # html5 doc, we'll replace it
             meta.getparent().remove(meta)
         for meta in html.xpath("//meta[@scheme]"): # remove obsolete formatted metas

--- a/ebookmaker/writers/__init__.py
+++ b/ebookmaker/writers/__init__.py
@@ -57,7 +57,7 @@ class BaseWriter(object):
             fp.write(bytes_)
 
 
-    def validate(self): # pylint: disable=R0201
+    def validate(self, job): # pylint: disable=R0201
         """ Validate the output with some (external) tool.
 
         Override this in a real writer.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.28'
+VERSION = '0.11.29'
 
 setup (
     name = 'ebookmaker',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup
 
-VERSION = '0.11.29'
+VERSION = '0.11.30'
 
 setup (
     name = 'ebookmaker',


### PR DESCRIPTION
With this release, Ebookmaker expands the HTML5 tags that won't cause validation failures for EPUB2.

0.11.30 December 10, 2021
- for EPUB, down-convert HTML5 tags to divs so the the files validate as EPUB2. The new div elements will add a class named the same as the html5 tag, so `<section>` becomes `<div class="section">`. Other attributes are preserved. In addition CSS selectors involving these elements will be transformed accordingly: for example `section` becomes `div.section`
    - section
    - figure  (initial style set to "margin: 1em 40px;",  copying from Firefox internal stylesheet.)
    - figcaption
    - header
    - footer
Users of these new tags need to check that their CSS does not conflict with the added classes or changed CSS. In almost all cases, avoiding HTML5 element names for CSS classes will prevent any conflict.
- for EPUB, move 'tfoot' elements to before 'tbody' (the order used in HTML4)
- for EPUB, remove any 'meta' elements using the 'property' attribute.
- add 'CRITICAL' notification for 'too-deep' errors
- reset parsers after txt jobs. fixes a bug when the text source file is linked from the html.
- EPUBCheck validation was broken. To use EPUBCheck validation, first download and install EPUBCheck from https://www.w3.org/publishing/epubcheck/. If the command to invoke it is  `java -jar /Applications/epubcheck-4.2.6/epubcheck.jar`, then add this line to ~/.ebookmaker or /etc/ebookmaker.conf: `epub_validator: java -jar /Applications/epubcheck-4.2.6/epubcheck.jar` then turn on validation by adding `--validate` to Ebookmaker's command line invocation or by setting validate to true in ~/.ebookmaker
