### PR TITLE
0.12.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - fixed a mismatch between the classname given to the cover and the corresponding css
 - added CSS page breaks before footer and after header
 - BeautifulSoup doesn't convert entities in script or style elements because HTML5 specifies these as CDATA. So our code has to handle cases where there are unexpected entities there.
+- remove ALL non-default attributes in replaced img, not just alt
 
 0.12.2 August 23,2022
 - xml escape headers extracted from text files

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.12.3 August 24,2022
+- fixed a mismatch between the classname given to the cover and the corresponding css
+- added CSS page breaks before footer and after header
+- BeautifulSoup doesn't convert entities in script or style elements because HTML5 specifies these as CDATA. So our code has to handle cases where there are unexpected entities there.
+
 0.12.2 August 23,2022
 - xml escape headers extracted from text files
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.2'
+VERSION = '0.12.3'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.2'
+VERSION = '0.12.3'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -442,9 +442,10 @@ class HTMLParserBase(ParserBase):
             if src not in manifest:
                 debug("strip_links: Replacing <img> with src %s not in manifest." % src)
                 image.tag = NS.xhtml.span
-                image.content = image.get('alt', '') 
-                del image.attrib['src']
-                del image.attrib['alt']
+                image.content = image.get('alt', '')
+                for attr  in image.attrib:
+                    if attr not in ["class", "dir", "id", "lang", "style", "title"]:
+                        del image.attrib[attr]
 
 
     def make_toc(self, xhtml):

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -72,6 +72,12 @@ div, p, pre, h1, h2, h3, h4, h5, h6 {
    margin-right: 0;
    display: block
    }
+section.pgheader{
+    page-break-after: always;
+    }
+section.pgfooter{
+    page-break-before: always;
+    }
 div.pgebub-root-div {
    margin: 0
    }

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -89,7 +89,7 @@ div.figcenter span.caption {
 a.pgkilled {
    text-decoration: none;
    }
-img.ebookmaker-cover {max-width: 100%;}
+img.x-ebookmaker-cover {max-width: 100%;}
 
 @media (orientation: landscape) {
     img.x-ebookmaker-cover {height: 100%;}

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -106,7 +106,7 @@ div.figcenter span.caption {
 a.pgkilled {
    text-decoration: none;
    }
-img.ebookmaker-cover {max-width: 100%;}
+img.x-ebookmaker-cover {max-width: 100%;}
 """
 
 OPS_TEXT_MEDIATYPES = set((
@@ -259,7 +259,7 @@ class OEBPSContainer(zipfile.ZipFile):
                        parsers.IMAGE_WRAPPER.format(src=img_url,
                                                     title=img_title,
                                                     backlink="",
-                                                    wrapper_class='x-ebookmaker-wrapper',
+                                                    wrapper_class='x-ebookmaker-cover',
                                                     doctype=gg.XHTML_DOCTYPE),
                        mt.xhtml)
         return filename


### PR DESCRIPTION
- fixed a mismatch between the classname given to the cover and the corresponding css
- added CSS page breaks before footer and after header
- BeautifulSoup doesn't convert entities in script or style elements because HTML5 specifies these as CDATA. So our code has to handle cases where there are unexpected entities there.
- remove ALL non-default attributes in replaced img, not just alt
