### PR TITLE
0.12.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Ebookmaker will now NEVER break a page in the middle of a table, a list, or a figure.
 - PG boilerplate is inserted in EPUB2 files as well
 - Fixed issue with special characters in the boilerplate dividers causing txt builds to fail
+- recognize previously marked pg-header, etc., such as from rst
 
 0.12.3 August 24,2022
 - fixed a mismatch between the classname given to the cover and the corresponding css

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.4
 - fixed bug in colgroup wrapping
+- Ebookmaker will now NEVER break a page in the middle of a table, a list, or a figure.
 
 0.12.3 August 24,2022
 - fixed a mismatch between the classname given to the cover and the corresponding css

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.4
+- fixed bug in colgroup wrapping
+
 0.12.3 August 24,2022
 - fixed a mismatch between the classname given to the cover and the corresponding css
 - added CSS page breaks before footer and after header

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.4
+0.12.4 August 31, 2022
 - fixed bug in colgroup wrapping
 - Ebookmaker will now NEVER break a page in the middle of a table, a list, or a figure.
 - PG boilerplate is inserted in EPUB2 files as well

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.12.4
 - fixed bug in colgroup wrapping
 - Ebookmaker will now NEVER break a page in the middle of a table, a list, or a figure.
+- PG boilerplate is inserted in EPUB2 files as well
+- Fixed issue with special characters in the boilerplate dividers causing txt builds to fail
 
 0.12.3 August 24,2022
 - fixed a mismatch between the classname given to the cover and the corresponding css

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.3'
+VERSION = '0.12.4'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.3'
+VERSION = '0.12.4'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -339,7 +339,7 @@ class Parser(HTMLParserBase):
             for col in table:
                 if col.tag == NS.xhtml.col:
                     colgroup.append(col)
-            table[0] = colgroup
+            table.insert(0, colgroup)
 
         # move lang to xml:lang
 

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -81,6 +81,10 @@ def check_patterns(node, patterns):
 
 def mark_soup(soup):
     def mark_bp(node, mark, markers, top=True):
+        marked = node.find(id=mark)
+        if marked:
+            marked.name = 'section'
+            return True
         divider = check_patterns(node, markers)
         if divider:
             # first, copy the element that contains the top (bottom) boilerplate divider 

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -136,7 +136,12 @@ def strip_headers_from_txt(text):
     divider_tail = ''
     if '\n' in text:
         divider_tail, text = text.split('\n', maxsplit=1)
-    pg_header = '\n'.join(['<pre id="pg-header">', xmlspecialchars(header_text), divider, divider_tail, '</pre>'])
+    pg_header = '\n'.join([
+        '<pre id="pg-header">',
+        xmlspecialchars(header_text),
+        xmlspecialchars(divider),
+        xmlspecialchars(divider_tail),
+        '</pre>'])
 
     text, divider, footer_text = markers_split(text, BOTTOM_MARKERS)
     pg_footer = '\n'.join(['<pre id="pg-footer">', divider, xmlspecialchars(footer_text), '</pre>'])

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -40,6 +40,7 @@ from ebookmaker.Version import VERSION, GENERATOR
 from ebookmaker.utils import (
     add_class, add_style, css_len, gg, xpath,
 )
+from . import HTMLWriter
 
 options = Options()
 
@@ -1289,6 +1290,7 @@ class Writer(writers.HTMLishWriter):
         ncx = TocNCX(job.dc)
         parserlist = []
         css_count = 0
+        boilerplate_done = False
 
         # add CSS parser
         self.add_external_css(job.spider, None, PRIVATE_CSS, 'pgepub.css')
@@ -1340,6 +1342,11 @@ class Writer(writers.HTMLishWriter):
                         p.parse()
                         xhtml = copy.deepcopy(p.xhtml) if hasattr(p, 'xhtml') else None
                     if xhtml is not None:
+                        if not boilerplate_done:
+                            HTMLWriter.Writer.replace_boilerplate(job, xhtml)
+                            boilerplate_done = True
+
+                        xhtml.make_links_absolute(base_url=p.attribs.url)
                         self.fix_html5(xhtml)
 
                         strip_classes = self.get_classes_with_prop(xhtml)


### PR DESCRIPTION
- fixed bug in colgroup wrapping
- Ebookmaker will now NEVER break a page in the middle of a table, a list, or a figure.
- PG boilerplate is inserted in EPUB2 files as well
- Fixed issue with special characters in the boilerplate dividers causing txt builds to fail
- recognize previously marked pg-header, etc., such as from rst
