### PR TITLE
0.12.7

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.7
+- fixed an ancient bug in pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.
+
 0.12.6 September 3, 2022
 - bad things happen if there's text at the top level. often this is a result of bad html. pre_parse now takes care of this
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.6
+0.12.6 September 3, 2022
 - bad things happen if there's text at the top level. often this is a result of bad html. pre_parse now takes care of this
 
 0.12.5 September 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
-0.12.7
-- fixed an ancient bug in pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.
+0.12.7 September 5, 2022
+- fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.
 
 0.12.6 September 3, 2022
 - bad things happen if there's text at the top level. often this is a result of bad html. pre_parse now takes care of this

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.6
+- bad things happen if there's text at the top level. often this is a result of bad html. pre_parse now takes care of this
+
 0.12.5 September 1, 2022
 There remain problems converting HTML 4.0 files.
 - fix failed txt build when boilerplate is not found

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-ebookmaker = {editable = true, path = "."}
 libgutenberg = ">=0.10.0"
 psycopg2 = "*"
 docutils = ">=0.18.1"
+ebookmaker = {editable = true, path = "."}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.0a1
+version = 0.12.4
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.4
+version = 0.12.7
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.5'
+VERSION = '0.12.6'
 
 if __name__ == "__main__":
  
@@ -83,6 +83,7 @@ if __name__ == "__main__":
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
         ],
 
         platforms = 'OS-independent'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.6'
+VERSION = '0.12.7'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.6'
+VERSION = '0.12.7'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.5'
+VERSION = '0.12.6'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -18,7 +18,7 @@ from six.moves import urllib
 import lxml.html
 from lxml import etree
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 from bs4.formatter import EntitySubstitution, HTMLFormatter
 
 
@@ -523,6 +523,13 @@ class Parser(HTMLParserBase):
             return
         soup.html['xmlns'] = NS.xhtml
         
+        # rap bare strings at body top level
+        for elem in soup.html.body.contents:
+            if isinstance(elem, NavigableString) and str(elem).strip(' \n\r\t'):
+                p = soup.new_tag('p')
+                p.string = str(elem)
+                elem.replace_with(p)
+
         marked = mark_soup(soup)
         if not marked:
             warning('no boilerplate found in %s', self.attribs.url)

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -74,6 +74,7 @@ BOGUS_CHARSET_NAMES = {'iso-latin-1': 'iso-8859-1',
                        # python has bogus codec name
                        'macintosh': 'mac_roman',
                        }
+COREATTRS = ["class", "dir", "id", "lang", "style", "title"]
 
 IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -444,7 +445,7 @@ class HTMLParserBase(ParserBase):
                 image.tag = NS.xhtml.span
                 image.content = image.get('alt', '')
                 for attr  in image.attrib:
-                    if attr not in ["class", "dir", "id", "lang", "style", "title"]:
+                    if attr not in COREATTRS:
                         del image.attrib[attr]
 
 


### PR DESCRIPTION
0.12.7 September 5, 2022
- fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.

0.12.6 September 3, 2022
- bad things happen if there's text at the top level. often this is a result of bad html. pre_parse now takes care of this
