### PR TITLE
0.12.8

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.8 September 6, 2022
+- fixed parsing no-footer text files (stupid mistake!)
+
 0.12.7 September 5, 2022
 - fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,9 @@
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)
 - fixed an issue where css files disappear because they are empty but there are still links to them
-- added some file checks and a custom exception so that it's clearer what has happened if you give ebookmaker a bad file
-- removed a css link in wrapper that was was getting stripped, then re-inserted later. 
+- added some file checks and a custom exception so that it's clearer what has happened if you give ebookmaker a bad file.
+- removed a css link in wrapper that was was getting stripped, then re-inserted later.
+- ancient browsers didn't understand stylesheets, so xml comments were used to hide the style text. Our CSS parser is too modern to remember this, it seems. So we needed to un-comment style text. Probably was another thing that tidy was doing without telling us.
 
 0.12.7 September 5, 2022
 - fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)
 - fixed an issue where css files disappear because they are empty but there are still links to them
+- added some file checks and a custom exception so that it's clearer what has happened if you give ebookmaker a bad file
 
 0.12.7 September 5, 2022
 - fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)
+- fixed an issue where css files disappear because they are empty but there are still links to them
 
 0.12.7 September 5, 2022
 - fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - fixed parsing no-footer text files (stupid mistake!)
 - fixed an issue where css files disappear because they are empty but there are still links to them
 - added some file checks and a custom exception so that it's clearer what has happened if you give ebookmaker a bad file
+- removed a css link in wrapper that was was getting stripped, then re-inserted later. 
 
 0.12.7 September 5, 2022
 - fixed an ancient bug in EPUB2 pageno handling. Having two children ids in a pageno-class element no longer generates validation errors for EPUB2 files. Yes, it seems odd that a book would have two page anchors in one page number floating element, but it makes sense if you look at the rendered HTML (#501), and it's no reason to mock people.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.7
+version = 0.12.8
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.7'
+VERSION = '0.12.8'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/CommonCode.py
+++ b/src/ebookmaker/CommonCode.py
@@ -23,6 +23,9 @@ class Struct(object):
 
 options = Options()
 
+class EbookmakerBadFileException(Exception):
+    pass
+
 class Job(object):
     """Hold 'globals' for a job.
 

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.7'
+VERSION = '0.12.8'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -530,8 +530,15 @@ class Parser(HTMLParserBase):
             raise EbookmakerBadFileException('unusable file')
 
         soup.html['xmlns'] = NS.xhtml
-        
-        # rap bare strings at body top level
+
+        # ancient browsers didn't understand stylesheets, so xml comments were used to hide the
+        # style text. Our CSS parser is too modern to remember this, it seems. 
+        # So we need to un-comment the sttyle text
+        xmlcomment = re.compile(r'<!--(.*?)-->', re.S)
+        for commented_style in soup.find_all('style', string=xmlcomment):
+            commented_style.string = xmlcomment.sub(r'\1', str(commented_style.string))
+
+        # wrap bare strings at body top level
         for elem in soup.html.body.contents:
             if isinstance(elem, NavigableString) and str(elem).strip(' \n\r\t'):
                 p = soup.new_tag('p')

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -27,7 +27,7 @@ from libgutenberg.Logger import critical, info, debug, warning, error
 from libgutenberg.MediaTypes import mediatypes as mt
 
 from ebookmaker import parsers
-from ebookmaker.CommonCode import Options
+from ebookmaker.CommonCode import Options, EbookmakerBadFileException
 from ebookmaker.utils import add_style, css_len, replace_elements, xpath
 from . import HTMLParserBase
 from .boilerplate import mark_soup
@@ -520,7 +520,15 @@ class Parser(HTMLParserBase):
             soup = BeautifulSoup(self.bytes_content(), 'lxml', exclude_encodings=["us-ascii"])
         except:
             critical('failed to parse %s', self.attribs.url)
-            return
+            raise EbookmakerBadFileException('failed parsing')
+        try:
+            if not soup.html.body.contents:
+                critical('body has no contents in ', self.attribs.url)
+                raise EbookmakerBadFileException('body has no contents')
+        except:
+            critical('%s is not a usable html file', self.attribs.url)
+            raise EbookmakerBadFileException('unusable file')
+
         soup.html['xmlns'] = NS.xhtml
         
         # rap bare strings at body top level

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -80,7 +80,6 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{title}</title>
-    <link href="pgepub.css" rel="stylesheet"/>
   </head>
   <body>
     <div style="text-align: center">

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -157,7 +157,7 @@ def strip_headers_from_txt(text):
 
     text, divider, footer_text = markers_split(text, BOTTOM_MARKERS)
     if divider is None:
-        pg_header = ''
+        pg_footer = ''
     else:
         pg_footer = '\n'.join(['<pre id="pg-footer">', divider, xmlspecialchars(footer_text), '</pre>'])
     return text, pg_header, pg_footer

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -978,7 +978,7 @@ class Writer(writers.HTMLishWriter):
                 p.parse_string(style.text)
                 try:
                     # pylint: disable=E1103
-                    style.text = p.sheet.cssText.decode('utf-8')
+                    style.text = p.sheet.cssText.decode('utf-8') or '/* empty style */'
                 except (ValueError, UnicodeError):
                     debug("CSS:\n%s" % p.sheet.cssText)
                     raise


### PR DESCRIPTION
- fixed parsing no-footer text files (stupid mistake!)
- fixed an issue where css files disappear because they are empty but there are still links to them
- added some file checks and a custom exception so that it's clearer what has happened if you give ebookmaker a bad file.
- removed a css link in wrapper that was was getting stripped, then re-inserted later.
- ancient browsers didn't understand stylesheets, so xml comments were used to hide the style text. Our CSS parser is too modern to remember this, it seems. So we needed to un-comment style text. Probably was another thing that tidy was doing without telling us.
