### PR TITLE
clean up problematic style elements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.9 September 15, 2022
 - restore stylesheet in cover wrapper
+- PG producers used to do all sorts of crazy things in css comments, such as nesting CDATA sections: `/*<![CDATA[ */`. tidy used to clean this up for us. Now we're removing css comments entirely.
 
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.12.9 September 15, 2022
 - restore stylesheet in cover wrapper
 - PG producers used to do all sorts of crazy things in css comments, such as nesting CDATA sections: `/*<![CDATA[ */`. tidy used to clean this up for us. Now we're removing css comments entirely.
+- what's more, the css sometimes contained malformed xml comments
 
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.9 September 15, 2022
+- restore stylesheet in cover wrapper
+
 0.12.8 September 6, 2022
 - fixed parsing no-footer text files (stupid mistake!)
 - fixed an issue where css files disappear because they are empty but there are still links to them

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.8
+version = 0.12.9
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.8'
+VERSION = '0.12.9'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.8'
+VERSION = '0.12.9'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -538,6 +538,11 @@ class Parser(HTMLParserBase):
         for commented_style in soup.find_all('style', string=xmlcomment):
             commented_style.string = xmlcomment.sub(r'\1', str(commented_style.string))
 
+        # pg producers did crazy things in css comments, such as inserting CDATA sections
+        csscomment = re.compile(r'/\*(.*?)\*/', re.S)
+        for commented_style in soup.find_all('style', string=csscomment):
+            commented_style.string = csscomment.sub('', str(commented_style.string))
+
         # wrap bare strings at body top level
         for elem in soup.html.body.contents:
             if isinstance(elem, NavigableString) and str(elem).strip(' \n\r\t'):

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -533,7 +533,7 @@ class Parser(HTMLParserBase):
 
         # ancient browsers didn't understand stylesheets, so xml comments were used to hide the
         # style text. Our CSS parser is too modern to remember this, it seems. 
-        # So we need to un-comment the sttyle text
+        # So we needed to un-comment the style text
         xmlcomment = re.compile(r'<!--(.*?)-->', re.S)
         for commented_style in soup.find_all('style', string=xmlcomment):
             commented_style.string = xmlcomment.sub(r'\1', str(commented_style.string))

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -538,6 +538,10 @@ class Parser(HTMLParserBase):
         for commented_style in soup.find_all('style', string=xmlcomment):
             commented_style.string = xmlcomment.sub(r'\1', str(commented_style.string))
 
+        xmlopencomment = re.compile(r'<!--(.*?)')
+        for commented_style in soup.find_all('style', string=xmlopencomment):
+            commented_style.string = xmlopencomment.sub(r'', str(commented_style.string))
+
         # pg producers did crazy things in css comments, such as inserting CDATA sections
         csscomment = re.compile(r'/\*(.*?)\*/', re.S)
         for commented_style in soup.find_all('style', string=csscomment):

--- a/src/ebookmaker/parsers/WrapperParser.py
+++ b/src/ebookmaker/parsers/WrapperParser.py
@@ -55,7 +55,8 @@ class Parser(HTMLParserBase):
             title=quoteattr(self.attribs.title),
             backlink=backlink,
             wrapper_class='x-ebookmaker-wrapper',
-            doctype=gg.XHTML_DOCTYPE)
+            doctype=gg.XHTML_DOCTYPE,
+            style='')
 
 
     def wrapper_url(self, img_url):

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -76,10 +76,12 @@ BOGUS_CHARSET_NAMES = {'iso-latin-1': 'iso-8859-1',
                        }
 COREATTRS = ["class", "dir", "id", "lang", "style", "title"]
 
+STYLE_LINK = '<link href="pgepub.css" rel="stylesheet"/>'
 IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>{title}</title>
+    {style}
   </head>
   <body>
     <div style="text-align: center">

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -119,7 +119,8 @@ class OEBPSContainer(EpubWriter.OEBPSContainer):
                                                     title=img_title,
                                                     backlink="",
                                                     wrapper_class='x-ebookmaker-cover',
-                                                    doctype=gg.HTML5_DOCTYPE),
+                                                    doctype=gg.HTML5_DOCTYPE,
+                                                    style=parsers.STYLE_LINK),
                        mt.xhtml)
         return filename
 

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -261,7 +261,8 @@ class OEBPSContainer(zipfile.ZipFile):
                                                     title=img_title,
                                                     backlink="",
                                                     wrapper_class='x-ebookmaker-cover',
-                                                    doctype=gg.XHTML_DOCTYPE),
+                                                    doctype=gg.XHTML_DOCTYPE,
+                                                    style=parsers.STYLE_LINK),
                        mt.xhtml)
         return filename
 


### PR DESCRIPTION
- restore stylesheet in cover wrapper
- PG producers used to do all sorts of crazy things in css comments, such as nesting CDATA sections: `/*<![CDATA[ */`. tidy used to clean this up for us. Now we're removing css comments entirely.
- what's more, the css sometimes contained malformed xml comments
