### PR TITLE
fix tei footer finding, tree caching, misc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.13 September 23, 2022
+- fix reversion in txt production because GutenbergTextParser needs caching
+
 0.12.12 September 22, 2022
 - caching the html tree in the parserwas causing the epub build to interfere with the epub3 build, so a reset method has been added for parsers to make themselves safe for reuse. Raw bytes are still cached, since most of the benefit of caching is reading from disk.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.11 September 19, 2022
+- allow figure in body
+
 0.12.10 September 18, 2022
 - fixed bad bug finding footer in texts generated from TEI
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.11 September 19, 2022
 - allow figure in body
+- let PDFWriter create a directory
 
 0.12.10 September 18, 2022
 - fixed bad bug finding footer in texts generated from TEI

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.12 September 22, 2022
+- caching the html tree in the parserwas causing the epub build to interfere with the epub3 build, so a reset method has been added for parsers to make themselves safe for reuse. Raw bytes are still cached, since most of the benefit of caching is reading from disk.
+
 0.12.11 September 19, 2022
 - allow figure in body
 - let PDFWriter create a directory

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.10 September 18, 2022
+- fixed bad bug finding footer in texts generated from TEI
+
 0.12.9 September 15, 2022
 - restore stylesheet in cover wrapper
 - PG producers used to do all sorts of crazy things in css comments, such as nesting CDATA sections: `/*<![CDATA[ */`. tidy used to clean this up for us. Now we're removing css comments entirely.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.9
+version = 0.12.10
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.10
+version = 0.12.11
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.12
+version = 0.12.13
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.11
+version = 0.12.12
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.9'
+VERSION = '0.12.10'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.10'
+VERSION = '0.12.11'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.11'
+VERSION = '0.12.12'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.12'
+VERSION = '0.12.13'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/ParserFactory.py
+++ b/src/ebookmaker/ParserFactory.py
@@ -88,6 +88,7 @@ class ParserFactory(object):
             # debug("... reusing parser for %s" % url)
             # reuse same parser, maybe already filled with data
             parser = cls.parsers[url]
+            parser.reset()
             parser.attribs.update(attribs)
             # debug(str(parser.attribs))
             return parser

--- a/src/ebookmaker/Spider.py
+++ b/src/ebookmaker/Spider.py
@@ -146,8 +146,6 @@ class Spider(object):
                             self.parsers.append(wrapper_parser)
                             self.parsed_urls.add(wrapper_parser.attribs.url)
                         
-                        # careful! we're changing the xml here, and the parser gets cached,
-                        # so make sure 'epub.images' is the last job done.
                         elem.set('href', wrapper_parser.attribs.url)
                         new_attribs.referrer = wrapper_parser.attribs.url
                         elem.set('title', wrapper_parser.attribs.title)

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.12'
+VERSION = '0.12.13'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.11'
+VERSION = '0.12.12'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.9'
+VERSION = '0.12.10'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.10'
+VERSION = '0.12.11'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/GutenbergTextParser.py
+++ b/src/ebookmaker/parsers/GutenbergTextParser.py
@@ -471,6 +471,12 @@ class Parser(HTMLParserBase):
         self.max_blanks = 0
         self.pars = []
 
+    def reset(self):
+        """ we DO want to cache the html here! 
+
+        """
+        pass
+
 
     def get_charset_from_meta(self):
         """ Parse text for hints about charset. """

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -97,7 +97,7 @@ DEPRECATED = {
 
 ALLOWED_IN_BODY = {
     NS.xhtml.address, NS.xhtml.article, NS.xhtml.blockquote, f'{NS.xhtml.de}l', NS.xhtml.div,
-    NS.xhtml.dl, NS.xhtml.footer, 
+    NS.xhtml.dl, NS.xhtml.figure, NS.xhtml.footer, 
     NS.xhtml.h1, NS.xhtml.h2, NS.xhtml.h3, NS.xhtml.h4, NS.xhtml.h5, NS.xhtml.h6,
     NS.xhtml.header, NS.xhtml.hr, NS.xhtml.ins, NS.xhtml.noscript, NS.xhtml.ol, NS.xhtml.p,
     NS.xhtml.pre, NS.xhtml.section, NS.xhtml.script, NS.xhtml.table, NS.xhtml.ul,

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -172,6 +172,16 @@ class ParserBase(object):
         self.unicode_buffer = None
 
 
+    def reset(self):
+        """ Make the parser safe for re-use.
+
+        This method is called before parser is reused and should be implemented if
+        data from a previous use needs cleaning up. 
+
+        """
+        pass
+
+
     def pre_parse(self):
         """ Do a lightweight parse, that allows iterlinks () to succeed.
 
@@ -353,6 +363,10 @@ class HTMLParserBase(ParserBase):
     def __init__(self, attribs=None):
         ParserBase.__init__(self, attribs)
         self.attribs.mediatype = ParserAttributes.HeaderElement(mt.xhtml)
+        self.xhtml = None
+
+
+    def reset(self):
         self.xhtml = None
 
 

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -18,10 +18,10 @@ pg_header
 
 pg_footer
     usually the license
-    
+
 pg_smallprint
-    on older books, this will contain license-ish language and other material. it's usually found 
-    at the top of the text, and is often comically dated. 
+    on older books, this will contain license-ish language and other material. it's usually found
+    at the top of the text, and is often comically dated.
 
 
 BeautifulSoup is used for its superior "scraping" tools.
@@ -31,7 +31,6 @@ BeautifulSoup is used for its superior "scraping" tools.
 import copy
 import re
 
-from bs4 import BeautifulSoup
 import soupsieve as sv
 
 from libgutenberg.GutenbergGlobals import xmlspecialchars
@@ -56,10 +55,10 @@ SMALLPRINT_MARKERS = [
 def prune(root, divider, after=True):
     ''' prune parts of the root element before or after a divider element '''
     def next_or_prev(el, after=True):
-         return el.next_sibling if after else el.previous_sibling
+        return el.next_sibling if after else el.previous_sibling
 
     def after_or_before(el, after=True):
-         return list(el.next_siblings) if after else list(el.previous_siblings)
+        return list(el.next_siblings) if after else list(el.previous_siblings)
 
     dividers = [divider] + list(divider.parents)
     keep = False
@@ -87,7 +86,7 @@ def mark_soup(soup):
             return True
         divider = check_patterns(node, markers)
         if divider:
-            # first, copy the element that contains the top (bottom) boilerplate divider 
+            # first, copy the element that contains the top (bottom) boilerplate divider
             # and content that precedes (follows) it
             top_el = copy.copy(node)
             if len(node.find_all(True, recursive=False)) == 1:
@@ -103,9 +102,8 @@ def mark_soup(soup):
                 if elem in divider.parents:
                     if top:
                         break
-                    else:
-                        bp_section.append(copy.copy(elem))
-                        in_bottom = True
+                    bp_section.append(copy.copy(elem))
+                    in_bottom = True
 
             # next remove the divider and anything before (after) the divider from the soup
             prune(node, divider, after=not top)
@@ -139,7 +137,7 @@ def mark_soup(soup):
 
 
 def strip_headers_from_txt(text):
-    ''' 
+    '''
     when input is plain text, strip the heaters and return (stripped_text, pg_header, pg_footer)
     '''
     def markers_split(text, markers):
@@ -172,5 +170,8 @@ def strip_headers_from_txt(text):
     if divider is None:
         pg_footer = ''
     else:
-        pg_footer = '\n'.join(['<pre id="pg-footer">', divider, xmlspecialchars(footer_text), '</pre>'])
+        pg_footer = '\n'.join(['<pre id="pg-footer">',
+                               divider,
+                               xmlspecialchars(footer_text),
+                               '</pre>'])
     return text, pg_header, pg_footer

--- a/src/ebookmaker/writers/PDFWriter.py
+++ b/src/ebookmaker/writers/PDFWriter.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 
 from libgutenberg.Logger import debug, info, warning, error
-from libgutenberg.GutenbergGlobals import SkipOutputFormat
+from libgutenberg.GutenbergGlobals import SkipOutputFormat, mkdir_for_filename
 
 from ebookmaker import ParserFactory
 from ebookmaker import writers
@@ -37,6 +37,7 @@ class Writer (writers.BaseWriter):
         debug ("Inputfile: %s" % inputfilename)
         info ("Creating PDF file: %s" % outputfilename)
 
+        mkdir_for_filename(outputfilename)
         parser = ParserFactory.ParserFactory.create (inputfilename)
 
         if not hasattr (parser, 'rst2xetex'):


### PR DESCRIPTION
- caching the html tree in the parserwas causing the epub build to interfere with the epub3 build, so a reset method has been added for parsers to make themselves safe for reuse. Raw bytes are still cached, since most of the benefit of caching is reading from disk.
- allow figure in body
- let PDFWriter create a directory
- fixed bad bug finding footer in texts generated from TEI
