### PR TITLE
grabbag of small fixes, much improved html4 transitional handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.16
+0.12.16 October 3, 2022
 - fix bug in removal of legacy elements
 - add back enclose_text removed in 0.12.14; it wasn't redundant
 - when an img is removed, replace it with alt text. fixes #123

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 0.12.16
 - fix bug in removal of legacy elements
-
+- add back enclose_text removed in 0.12.14; it wasn't redundant
 
 0.12.15 October 1, 2022
 - fixed bug exposed by implementation of downloaded pubinfo in libgutenberg

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.12.16
 - fix bug in removal of legacy elements
 - add back enclose_text removed in 0.12.14; it wasn't redundant
+- when an img is removed, replace it with alt text. fixes #123
 
 0.12.15 October 1, 2022
 - fixed bug exposed by implementation of downloaded pubinfo in libgutenberg

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
-0.12.15 (October 1, 2022
+0.12.16
+- fix bug in removal of legacy elements
+
+
+0.12.15 October 1, 2022
 - fixed bug exposed by implementation of downloaded pubinfo in libgutenberg
 - updated libgutenberg to 0.10.5 to fix an older bug revealed by rendering bugfix
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - fix bug in removal of legacy elements
 - add back enclose_text removed in 0.12.14; it wasn't redundant
 - when an img is removed, replace it with alt text. fixes #123
+- It seems we have to use the EPUB2 method to declare the cover image for EPUB3 files.
 
 0.12.15 October 1, 2022
 - fixed bug exposed by implementation of downloaded pubinfo in libgutenberg

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.15
+version = 0.12.16
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.15'
+VERSION = '0.12.16'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.15'
+VERSION = '0.12.16'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -275,6 +275,18 @@ class Parser(HTMLParserBase):
                     elem.attrib[new_key] = val
 
 
+    def enclose_text(self):
+        """ same as setting enclose-text option on tidy;
+        ' enclose any text it finds in the body element within a <P> element.
+        This is useful when you want to take existing HTML and use it with a style sheet.'
+        """
+        for elem in self.xhtml.body:
+            if elem.tag not in ALLOWED_IN_BODY:
+                new_p = elem.makeelement(NS.xhtml.p)
+                elem.addprevious(new_p)
+                new_p.append(elem)
+
+
     def _to_xhtml11(self):
         """ Make vanilla xhtml more conform to xhtml 1.1 """
 
@@ -384,6 +396,9 @@ class Parser(HTMLParserBase):
 
         # deprecated elements -  replace with <span/div class="xhtml_{tag name}">
         deprecated_used = replace_elements(self.xhtml, REPLACE_ELEMENTS)
+
+        # enclose text the way tidy does
+        self.enclose_text()
 
         ##### cleanup #######
 

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -458,7 +458,7 @@ class HTMLParserBase(ParserBase):
             if src not in manifest:
                 debug("strip_links: Replacing <img> with src %s not in manifest." % src)
                 image.tag = NS.xhtml.span
-                image.content = image.get('alt', '')
+                image.text = image.get('alt', '')
                 for attr  in image.attrib:
                     if attr not in COREATTRS:
                         del image.attrib[attr]

--- a/src/ebookmaker/utils.py
+++ b/src/ebookmaker/utils.py
@@ -67,6 +67,6 @@ def replace_elements(xhtml, deprecated):
                 add_class(elem, 'xhtml_' + tag)
                 elem.tag = getattr(NS.xhtml, deprecated[tag])
             else:
-                elem.getparent().remove(meta)
+                elem.getparent().remove(elem)
             deprecated_used.add(tag)
     return deprecated_used

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -324,7 +324,7 @@ class ContentOPF(object):
             self.item_id += 1
             id_ = 'item%d' % self.item_id
 
-        if prop == 'cover':
+        if prop == 'cover-image':
             self.add_coverpage(url, id_)
         manifest_atts = {'href': url, 'id': id_, 'media-type': mediatype}
         if mediatype == 'image/svg+xml':


### PR DESCRIPTION
- fix bug in removal of legacy elements
- add back enclose_text removed in 0.12.14; it wasn't redundant
- when an img is removed, replace it with alt text. fixes #123
- It seems we have to use the EPUB2 method to declare the cover image for EPUB3 files. fixes #129
