### PR TITLE
fix exception catching on job loop

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.17
 - handle pre-html5 type attribute of `ul` properly
+- continue processing job queue after a parse failure
 
 0.12.16 October 3, 2022
 - fix bug in removal of legacy elements

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.17
+0.12.17 October 6, 2022
 - handle pre-html5 type attribute of `ul` properly
 - continue processing job queue after a parse failure
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.17
+- handle pre-html5 type attribute of `ul` properly
+
 0.12.16 October 3, 2022
 - fix bug in removal of legacy elements
 - add back enclose_text removed in 0.12.14; it wasn't redundant

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.16
+version = 0.12.17
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.16'
+VERSION = '0.12.17'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -596,9 +596,9 @@ def main():
                 dc.session.close()
                 dc.session = None # probably overkill
         except Exception as e:
-            error('Job failed for type %s from %s', job.type, job.url)
+            critical('Job failed for type %s from %s', job.type, job.url)
             exception(e)
-            return 1
+            continue
 
     packager = PackagerFactory.create(options.packager, 'push')
     if packager:

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.16'
+VERSION = '0.12.17'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -116,7 +116,7 @@ REPLACEMENTS = [
     ('font', 'size', 'font-size', lambda x: FONT_SIZES.get(x.strip(), 'medium')),
     ('table td th', 'height', 'height', css_len),
     ('table td th pre', 'width', 'width', css_len),
-    ('li ol ul', 'type', 'list-style-type', lambda x: LIST_STYLES.get(x.strip(), '')),
+    ('li ol ul', 'type', 'list-style-type', lambda x: LIST_STYLES.get(x.strip(), x.strip())),
 ]
 
 CSS_FOR_REPLACED = {


### PR DESCRIPTION
- handle pre-html5 type attribute of `ul` properly
- continue processing job queue after a parse failure
