### PR TITLE
november bugfixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.21 
+0.12.22 November 28, 2022
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
 - add pagebreak css for EPUB2 boilerplate
 - changed log level for empty img[alt] from ERROR to WARNING
@@ -13,7 +13,7 @@
 - add svg cover from #132
 - remove 'svg' property for stand-alone svg files; this property is meant for files that embed svg.
 
-0.12.20 November 1, 2022
+0.12.21 November 1, 2022
 - add logging for empty img[alt] attributes
 
 0.12.20 October 23, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.20 
+- add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
+
+
 0.12.20 November 1, 2022
 - add logging for empty img[alt] attributes
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.20 
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
+- add pagebreak css for EPUB2 boilerplate
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - fix replacement css for table[align] and img[align]
 - fix incorrect css for bgcolor attributes
 - fix incorrect css for clear='all'
+- changed the approach to replacing `<center>` - there's additional css for tables in a center element.
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.19 October xx, 2022
+- don't wipe source credit if there's an update credit from the db.
+- require libgutenberg>=0.10.8
+
 0.12.19 October 17, 2022
 - tweak boilerplate to align with PG practice
 - use `*** START OF THE` instead of `*** START OF THIS`. PG shifted from `THIS` to `THE` around #64000.

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,10 @@
 - fix incorrect css for bgcolor attributes
 - fix incorrect css for clear='all'
 - changed the approach to replacing `<center>` - there's additional css for tables in a center element.
-
+- the HTML void element `wbr` is not recognized by lxml. for this reason, we had to
+    - switch to `html.parser` for files likely to be html5 (not xml)
+    - we're using `html.parser` for files that don't set `xmlns` attribute and don't declare a PUBLIC doctype `-//W3C//DTD`, which should be any non-xml HTML5 file. Only 151 files in our collection satisfy this criterion so far.
+    - explicitly remove stray end tags: `</wbr>` after writing to out bytes for the html5 file
 
 0.12.20 November 1, 2022
 - add logging for empty img[alt] attributes

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - changed log level for empty img[alt] from ERROR to WARNING
 - fix replacement css for table[align] and img[align]
 - fix incorrect css for bgcolor attributes
+- fix incorrect css for clear='all'
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
 - add pagebreak css for EPUB2 boilerplate
 - changed log level for empty img[alt] from ERROR to WARNING
+- fix replacement css for table[align] and img[align]
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.19 October xx, 2022
+0.12.20 October 23, 2022
 - don't wipe source credit if there's an update credit from the db.
 - require libgutenberg>=0.10.8
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.20 
+0.12.21 
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
 - add pagebreak css for EPUB2 boilerplate
 - changed log level for empty img[alt] from ERROR to WARNING
@@ -10,6 +10,8 @@
     - switch to `html.parser` for files likely to be html5 (not xml)
     - we're using `html.parser` for files that don't set `xmlns` attribute and don't declare a PUBLIC doctype `-//W3C//DTD`, which should be any non-xml HTML5 file. Only 151 files in our collection satisfy this criterion so far.
     - explicitly remove stray end tags: `</wbr>` after writing to out bytes for the html5 file
+- add svg cover from #132
+- remove 'svg' property for stand-alone svg files; this property is meant for files that embed svg.
 
 0.12.20 November 1, 2022
 - add logging for empty img[alt] attributes

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - add pagebreak css for EPUB2 boilerplate
 - changed log level for empty img[alt] from ERROR to WARNING
 - fix replacement css for table[align] and img[align]
+- fix incorrect css for bgcolor attributes
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.12.20 
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
 - add pagebreak css for EPUB2 boilerplate
+- changed log level for empty img[alt] from ERROR to WARNING
 
 
 0.12.20 November 1, 2022

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.20 November 1, 2022
+- add logging for empty img[alt] attributes
+
 0.12.20 October 23, 2022
 - don't wipe source credit if there's an update credit from the db.
 - require libgutenberg>=0.10.8

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.5"
+libgutenberg = ">=0.10.8"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 ebookmaker = {editable = true, path = "."}

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.8"
+libgutenberg = ">=0.10.9"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 ebookmaker = {editable = true, path = "."}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.21
+version = 0.12.22
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.19
+version = 0.12.20
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.20
+version = 0.12.21
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             'roman',
             'requests',
             'six>=1.4.1',
-            'libgutenberg[covers]>=0.10.5',
+            'libgutenberg[covers]>=0.10.8',
             'cchardet',
             'beautifulsoup4',
         ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.21'
+VERSION = '0.12.22'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.20'
+VERSION = '0.12.21'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.19'
+VERSION = '0.12.20'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Spider.py
+++ b/src/ebookmaker/Spider.py
@@ -158,6 +158,8 @@ class Spider(object):
                         self.enqueue(queue, depth + 1, new_attribs, True)
                         
                 elif tag in (NS.xhtml.img, NS.xhtml.style):
+                    if 'alt' in elem.attrib and elem.attrib['alt'] == '':
+                        error('Empty alt tag for %s', url)
                     self.enqueue(queue, depth, new_attribs, False)
                 elif tag == NS.xhtml.link:
                     if new_attribs.rel.intersection(('stylesheet', 'icon')):

--- a/src/ebookmaker/Spider.py
+++ b/src/ebookmaker/Spider.py
@@ -27,6 +27,8 @@ from ebookmaker import parsers
 from ebookmaker.CommonCode import Options
 from ebookmaker.ParserFactory import ParserFactory
 
+NO_ALT_TEXT = 'Empty alt text for %s. See https://www.w3.org/WAI/tutorials/images/ for info on accessible alt text.'
+
 options = Options()
 
 class Spider(object):
@@ -159,7 +161,7 @@ class Spider(object):
                         
                 elif tag in (NS.xhtml.img, NS.xhtml.style):
                     if 'alt' in elem.attrib and elem.attrib['alt'] == '':
-                        error('Empty alt tag for %s', url)
+                        warning(NO_ALT_TEXT, url)
                     self.enqueue(queue, depth, new_attribs, False)
                 elif tag == NS.xhtml.link:
                     if new_attribs.rel.intersection(('stylesheet', 'icon')):

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.19'
+VERSION = '0.12.20'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.20'
+VERSION = '0.12.21'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.21'
+VERSION = '0.12.22'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -121,7 +121,7 @@ ALLOWED_IN_BODY = {
 
 REPLACEMENTS = [
     ('*', 'bgcolor', 'background-color', lambda x: x),
-    ('br', 'clear', 'clear', lambda x: x),
+    ('br', 'clear', 'clear', lambda x: 'both' if x == 'all' else x),
     ('caption div h1 h2 h3 h4 h5 h5 p', 'align', 'text-align', lambda x: x),
     ('hr', 'width', 'width', css_len),
     ('hr', 'size', 'border', css_len),

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -541,9 +541,13 @@ class Parser(HTMLParserBase):
             return
 
         debug("HTMLParser.pre_parse() ...")
-
+        if b'xmlns=' in self.bytes_content() or b'-//W3C//DTD' in self.bytes_content():
+            bs_parser = 'lxml'
+        else:
+            info('using html.parser')
+            bs_parser = 'html.parser'
         try:
-            soup = BeautifulSoup(self.bytes_content(), 'lxml', exclude_encodings=["us-ascii"])
+            soup = BeautifulSoup(self.bytes_content(), bs_parser, exclude_encodings=["us-ascii"])
         except:
             critical('failed to parse %s', self.attribs.url)
             raise EbookmakerBadFileException('failed parsing')

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -120,7 +120,7 @@ ALLOWED_IN_BODY = {
 }
 
 REPLACEMENTS = [
-    ('*', 'bgcolor', 'color', lambda x: x),
+    ('*', 'bgcolor', 'background-color', lambda x: x),
     ('br', 'clear', 'clear', lambda x: x),
     ('caption div h1 h2 h3 h4 h5 h5 p', 'align', 'text-align', lambda x: x),
     ('hr', 'width', 'width', css_len),

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -66,6 +66,7 @@ URI_MARK_CHARS = "-_.!~*'()"
 URI_RESERVED_CHARS = ';/?:@&=+$,'
 
 RE_URI_FRAGMENT = re.compile('[' + URI_MARK_CHARS + URI_RESERVED_CHARS + '%A-Za-z0-9]+')
+RE_NO_WS = re.compile(r'^\S.*')
 
 # all bogus encoding names used in PG go in here
 BOGUS_CHARSET_NAMES = {'iso-latin-1': 'iso-8859-1',
@@ -490,7 +491,8 @@ class HTMLParserBase(ParserBase):
                 also, replace breaks with whitespace. tidy used to put whitespace around <br>
                 elements. PPs relied on this behavior, so we're stuck. """
             for br in xpath(header, '//xhtml:br'):
-                br.tail = br.tail or '\n'
+                if RE_NO_WS.match(str(br.tail)):
+                    br.tail = '\n' + str(br.tail)
 
             text = gg.normalize(etree.tostring(header,
                                                method="text",

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -486,7 +486,12 @@ class HTMLParserBase(ParserBase):
                 i += 1
 
         def get_header_text(header):
-            """ clean header text """
+            """ clean header text
+                also, replace breaks with whitespace. tidy used to put whitespace around <br>
+                elements. PPs relied on this behavior, so we're stuck. """
+            for br in xpath(header, '//xhtml:br'):
+                br.tail = br.tail or '\n'
+
             text = gg.normalize(etree.tostring(header,
                                                method="text",
                                                encoding=six.text_type,

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -95,33 +95,49 @@ div.figcenter span.caption {
 a.pgkilled {
    text-decoration: none;
    }
-img.x-ebookmaker-cover {max-width: 100%;}
+.x-ebookmaker-cover {
+      background-color: grey;
+      text-align: center;
+      padding: 0pt;
+      margin: 0pt;
+      page-break-after: always;
+      text-indent: 0;
+      width: 100%;
+      height: 100%;
+    }
 
-@media (orientation: landscape) {
-    img.x-ebookmaker-cover {height: 100%;}
-    }
-@media (orientation: portrait) {
-    img.x-ebookmaker-cover {width: 100%;}
-    }
+body.x-ebookmaker-coverpage {
+    margin: 0;
+    padding: 0;
+}
 """
 
 class OEBPSContainer(EpubWriter.OEBPSContainer):
     """ Class representing an OEBPS Container. """
 
 
-    def add_image_wrapper(self, img_url, img_title):
+    def add_cover_wrapper(self, parser):
         """ Add a HTML file wrapping img_url. """
-        img_title = quoteattr(img_title)
         filename = 'wrap%04d.xhtml' % self.wrappers
         self.wrappers += 1
-        self.add_bytes(filename,
-                       parsers.IMAGE_WRAPPER.format(src=img_url,
-                                                    title=img_title,
-                                                    backlink="",
-                                                    wrapper_class='x-ebookmaker-cover',
-                                                    doctype=gg.HTML5_DOCTYPE,
-                                                    style=parsers.STYLE_LINK),
-                       mt.xhtml)
+        (cover_x, cover_y) = parser.get_image_dimen()
+        wrapper = f'''
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>"Cover"</title>
+    <link href="pgepub.css" rel="stylesheet"/>
+  </head>
+<body class="x-ebookmaker-coverpage">
+  <div class="x-ebookmaker-cover">
+    <svg xmlns="http://www.w3.org/2000/svg" height="100%" preserveAspectRatio="xMidYMid meet" version="1.1" viewBox="0 0 {cover_x} {cover_y}" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <image width="{cover_x}" height="{cover_y}" xlink:href="{Writer.url2filename(parser.attribs.url)}"/>
+    </svg>
+  </div>
+</body>
+</html>        
+'''
+        self.add_bytes(filename, wrapper, mt.xhtml)
         return filename
 
 
@@ -327,8 +343,6 @@ class ContentOPF(object):
         if prop == 'cover-image':
             self.add_coverpage(url, id_)
         manifest_atts = {'href': url, 'id': id_, 'media-type': mediatype}
-        if mediatype == 'image/svg+xml':
-            prop = add_prop(prop, 'svg')
         if prop:
             manifest_atts['properties'] = prop
         self.manifest.append(
@@ -345,7 +359,8 @@ class ContentOPF(object):
             # make a new one
             id_ = None
 
-        id_ = self.manifest_item(url, mediatype, id_)
+        prop = 'svg' if id_ == 'coverpage-wrapper' else None
+        id_ = self.manifest_item(url, mediatype, id_, prop=prop)
 
         # HACK: ADE needs cover flow as first element
         # but we don't know if we have a native coverpage until the manifest is complete
@@ -567,16 +582,18 @@ class Writer(EpubWriter.Writer):
 
             for p in parserlist:
                 if 'icon' in p.attribs.rel:
-                    cover_url = p.attribs.url
+                    cover_parser = p
                     break
             else:
                 # no  cover items. should not happen
                 critical('no cover image available. turn on --generate_cover option')
-                cover_url = ''
+                cover_parser = None
 
             #register an ADE cover
-            href = ocf.add_image_wrapper(Writer.url2filename(cover_url), 'Cover')
-            opf.spine_item(href, mt.xhtml, id_='coverpage-wrapper', first=True)
+            if cover_parser:
+                href = ocf.add_cover_wrapper(cover_parser)
+                opf.spine_item(href, mt.xhtml, id_='coverpage-wrapper', first=True)
+                
 
             opf.rewrite_links(self.url2filename)
             ocf.add_unicode('content.opf', str(opf))

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -108,6 +108,8 @@ a.pgkilled {
    text-decoration: none;
    }
 img.x-ebookmaker-cover {max-width: 100%;}
+#pg-header {page-break-after: always;}
+#pg-footer {page-break-before: always;}
 """
 
 OPS_TEXT_MEDIATYPES = set((

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -158,11 +158,10 @@ class Writer(writers.HTMLishWriter):
     @staticmethod
     def replace_boilerplate(job, tree):
         # get text after the divider, put in dc.credit if not already there
-        if not job.dc.credit:
-            for pre in xpath(tree, '//*[@id="pg-header"]//xhtml:pre'):
-                divided = DIVIDER.split(' '.join(pre.itertext()))
-                if len(divided) > 1:
-                    job.dc.credit = divided[1]
+        for pre in xpath(tree, '//*[@id="pg-header"]//xhtml:pre'):
+            divided = DIVIDER.split(' '.join(pre.itertext()))
+            if len(divided) > 1:
+                job.dc.add_credit(divided[1])
 
         body = None
         for body in xpath(tree, '//xhtml:body'):

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -44,7 +44,7 @@ CSS_FOR_REPLACED = {
     .xhtml_center {text-align: center; display: block;}
     .xhtml_center table {
         display: table;
-        text-align: start;
+        text-align: left;
         margin-left: auto;
         margin-right: auto;
         }''',

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -122,11 +122,18 @@ DIVIDER = re.compile(r'\*\*+.*\*\*+')
 
 def serialize(xhtml):
     """ mode is html or xml """
-    return etree.tostring(xhtml,
+    htmlbytes = etree.tostring(xhtml,
                           method='html',
                           doctype=gg.HTML5_DOCTYPE,
                           encoding='utf-8',
                           pretty_print=False)
+
+    # lxml refuses to omit close tags for these elements
+    for newtag in [b'</wbr>',]:
+        htmlbytes = htmlbytes.replace(newtag, b'')
+
+    return htmlbytes
+
 
 class Writer(writers.HTMLishWriter):
     """ Class for writing HTML files. """
@@ -414,7 +421,6 @@ class Writer(writers.HTMLishWriter):
         for tfoot in xpath(html, "//xhtml:table/xhtml:tfoot"):
             table = tfoot.getparent()
             table.append(tfoot)
-
 
         ##### cleanup #######
 

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -40,7 +40,14 @@ CSS_FOR_REPLACED = {
     'big': ".xhtml_big {font-size: larger;}",
     'tt': ".xhtml_tt {font-family: monospace;}",
     # add some needed CSS3
-    '*': ".xhtml_center {justify-content: center; display: flex;}",
+    '*': '''
+    .xhtml_center {text-align: center; display: block;}
+    .xhtml_center table {
+        display: table;
+        text-align: start;
+        margin-left: auto;
+        margin-right: auto;
+        }''',
 }
 
 ## from https://hg.mozilla.org/mozilla-central/file/3fd770ef6a65/layout/style/html.css#l310


### PR DESCRIPTION
0.12.22 November 28, 2022
- add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
- add pagebreak css for EPUB2 boilerplate
- changed log level for empty img[alt] from ERROR to WARNING
- fix replacement css for table[align] and img[align]
- fix incorrect css for bgcolor attributes
- fix incorrect css for clear='all'
- changed the approach to replacing `<center>` - there's additional css for tables in a center element.
- the HTML void element `wbr` is not recognized by lxml. for this reason, we had to
    - switch to `html.parser` for files likely to be html5 (not xml)
    - we're using `html.parser` for files that don't set `xmlns` attribute and don't declare a PUBLIC doctype `-//W3C//DTD`, which should be any non-xml HTML5 file. Only 151 files in our collection satisfy this criterion so far.
    - explicitly remove stray end tags: `</wbr>` after writing to out bytes for the html5 file
- add svg cover from #132
- remove 'svg' property for stand-alone svg files; this property is meant for files that embed svg.

0.12.21 November 1, 2022
- add logging for empty img[alt] attributes
