### PR TITLE
cleanup for November

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.23 November 29, 2022
+- fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS
+- switch to `html5lib` for files likely to be html5 (not xml). This has the effect of closing any tags for empty elements not closed in the source file. Much slower than the C-based parsers used for XHTML, but probably not a big hit because results are cached.
+
 0.12.22 November 28, 2022
 - add whitespace to `<br>` elements in headers. tidy used to put whitespace around `<br>` elements. PPs relied on this behavior, so we're stuck.
 - add pagebreak css for EPUB2 boilerplate

--- a/Pipfile
+++ b/Pipfile
@@ -12,3 +12,4 @@ libgutenberg = ">=0.10.9"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 ebookmaker = {editable = true, path = "."}
+html5lib = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.22
+version = 0.12.23
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
             'libgutenberg[covers]>=0.10.8',
             'cchardet',
             'beautifulsoup4',
+            'html5lib',
         ],
     
         package_data = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.22'
+VERSION = '0.12.23'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.22'
+VERSION = '0.12.23'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -544,8 +544,8 @@ class Parser(HTMLParserBase):
         if b'xmlns=' in self.bytes_content() or b'-//W3C//DTD' in self.bytes_content():
             bs_parser = 'lxml'
         else:
-            info('using html.parser')
-            bs_parser = 'html.parser'
+            info('using html5lib')
+            bs_parser = 'html5lib'
         try:
             soup = BeautifulSoup(self.bytes_content(), bs_parser, exclude_encodings=["us-ascii"])
         except:

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -492,7 +492,7 @@ class HTMLParserBase(ParserBase):
                 elements. PPs relied on this behavior, so we're stuck. """
             for br in xpath(header, '//xhtml:br'):
                 if RE_NO_WS.match(str(br.tail)):
-                    br.tail = '\n' + str(br.tail)
+                    br.tail = '\n' + str(br.tail) if br.tail else '\n'
 
             text = gg.normalize(etree.tostring(header,
                                                method="text",

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -996,7 +996,7 @@ class Writer(writers.HTMLishWriter):
             if len(elem) > 0:
                 elem[-1].tail = elem[-1].tail + after if elem[-1].tail else after
             else:
-                elem.text = elem.text +after
+                elem.text = elem.text + after
 
         # nested quotes
         for q in xpath(xhtml, "//xhtml:q//xhtml:q"):


### PR DESCRIPTION
- fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS
- switch to `html5lib` for files likely to be html5 (not xml). This has the effect of closing any tags for empty elements not closed in the source file. Much slower than the C-based parsers used for XHTML, but probably not a big hit because results are cached.