### PR TITLE
0.12.24

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - don't set exclude_encodings param for html5lib parser
 - improve info log message for parser selection
 - header removal was messed up by language tags in the marker. removed them
+- MIN_CHUNK_SIZE reduced from 1024 bytes to 256 bytes. fixes #147
 
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - improve info log message for parser selection
 - header removal was messed up by language tags in the marker. removed them
 - MIN_CHUNK_SIZE reduced from 1024 bytes to 256 bytes. fixes #147
+- update to libgutenberg 0.10.13 to include plural creator roles
 
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.24 Dexember xx, 2022
+0.12.24 December 26, 2022
 - use same method as Autocat3 for resering PubInfo
 - in generated header, render each creator on a separate line
 - don't set exclude_encodings param for html5lib parser

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.12.24 Dexember xx, 2022
 - use same method as Autocat3 for resering PubInfo
 - in generated header, render each creator on a separate line
+- don't set exclude_encodings param for html5lib parser
+- improve info log message for parser selection
 
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.24 Dexember xx, 2022
+- use same method as Autocat3 for resering PubInfo
+
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS
 - switch to `html5lib` for files likely to be html5 (not xml). This has the effect of closing any tags for empty elements not closed in the source file. Much slower than the C-based parsers used for XHTML, but probably not a big hit because results are cached.

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - in generated header, render each creator on a separate line
 - don't set exclude_encodings param for html5lib parser
 - improve info log message for parser selection
+- header removal was messed up by language tags in the marker. removed them
 
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.24 Dexember xx, 2022
 - use same method as Autocat3 for resering PubInfo
+- in generated header, render each creator on a separate line
 
 0.12.23 November 29, 2022
 - fix the fix to the whitespace around `<br>` to fix issue with 'None' appearing in EPUBS

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.9"
+libgutenberg = ">=0.10.13"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 ebookmaker = {editable = true, path = "."}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.23
+version = 0.12.24
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             'roman',
             'requests',
             'six>=1.4.1',
-            'libgutenberg[covers]>=0.10.8',
+            'libgutenberg[covers]>=0.10.13',
             'cchardet',
             'beautifulsoup4',
             'html5lib',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.23'
+VERSION = '0.12.24'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -581,11 +581,11 @@ def main():
             output_files[job.type] = job.outputfile
             if job.type.startswith('kindle'):
                 absoutputdir = os.path.abspath(job.outputdir)
-                if job.type == 'kindle.images':
+                if job.type == 'kindle.images' and 'epub.images' in output_files:
                     job.url = os.path.join(absoutputdir, output_files['epub.images'])
-                elif job.type == 'kindle.noimages':
+                elif job.type == 'kindle.noimages' and 'epub.noimages' in output_files:
                     job.url = os.path.join(absoutputdir, output_files['epub.noimages'])
-            if job.type.startswith('kf8'):
+            if job.type.startswith('kf8') and 'epub3.images' in output_files:
                 absoutputdir = os.path.abspath(job.outputdir)
                 job.url = os.path.join(absoutputdir, output_files['epub3.images'])
 

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -143,10 +143,10 @@ def check_cover_size(p):
         dimen = p.get_image_dimen()
         if (dimen[0] * dimen[1]) > COVERPAGE_MIN_AREA:
             return True
-        else:
-            p_url = p.url if hasattr(p, 'url') else ''
-            warning("coverpage candidate %s is too small (%d x %d)" %
-                    (p_url, dimen[0], dimen[1]))
+
+        p_url = p.url if hasattr(p, 'url') else ''
+        warning("coverpage candidate %s is too small (%d x %d)" %
+                (p_url, dimen[0], dimen[1]))
     return False
 
 

--- a/src/ebookmaker/HTMLChunker.py
+++ b/src/ebookmaker/HTMLChunker.py
@@ -31,7 +31,7 @@ from ebookmaker.CommonCode import Options
 options = Options()
 
 MAX_CHUNK_SIZE = 100 * 1024  # bytes
-MIN_CHUNK_SIZE = 1024  # bytes
+MIN_CHUNK_SIZE = 256  # bytes
 
 SECTIONS = [
     ('div.section', 0.0),

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.23'
+VERSION = '0.12.24'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -112,7 +112,7 @@ COMPLEX_REPLACEMENTS = [(
 
 ALLOWED_IN_BODY = {
     NS.xhtml.address, NS.xhtml.article, NS.xhtml.blockquote, f'{NS.xhtml.de}l', NS.xhtml.div,
-    NS.xhtml.dl, NS.xhtml.figure, NS.xhtml.footer, 
+    NS.xhtml.dl, NS.xhtml.figure, NS.xhtml.footer,
     NS.xhtml.h1, NS.xhtml.h2, NS.xhtml.h3, NS.xhtml.h4, NS.xhtml.h5, NS.xhtml.h6,
     NS.xhtml.header, NS.xhtml.hr, NS.xhtml.ins, NS.xhtml.noscript, NS.xhtml.ol, NS.xhtml.p,
     NS.xhtml.pre, NS.xhtml.section, NS.xhtml.script, NS.xhtml.table, NS.xhtml.ul,
@@ -459,11 +459,10 @@ class Parser(HTMLParserBase):
                 coverpage.attrib.update(cover_attrs)
                 debug("overrode link to coverpage with %s." % coverpage_url)
 
-            else:
-                for head in xpath(self.xhtml, "/xhtml:html/xhtml:head"):
-                    head.append(parsers.em.link(rel='icon', href=coverpage_url,
-                                                type='image/x-cover'))
-                    debug("Inserted link to coverpage %s." % coverpage_url)
+            for head in xpath(self.xhtml, "/xhtml:html/xhtml:head"):
+                head.append(parsers.em.link(rel='icon', href=coverpage_url,
+                                            type='image/x-cover'))
+                debug("Inserted link to coverpage %s." % coverpage_url)
             return
 
         for coverpage in coverpages:
@@ -516,15 +515,15 @@ class Parser(HTMLParserBase):
             if m and m.group(1):
                 html = fix_bad_entity(m.group(1), html)
                 return self.__parse(html)
-            else:
-                error("Failed to parse file because: %s" % what)
-                mline = re.search(r'line\s(\d+),', str(what))
-                if mline:
-                    lineno = int(mline.group(1))
-                    if html:
-                        error("Line %d: %s" % (lineno, html.splitlines()[lineno - 1]))
-                    else:
-                        error("empty document")
+
+            error("Failed to parse file because: %s" % what)
+            mline = re.search(r'line\s(\d+),', str(what))
+            if mline:
+                lineno = int(mline.group(1))
+                if html:
+                    error("Line %d: %s" % (lineno, html.splitlines()[lineno - 1]))
+                else:
+                    error("empty document")
 
 
     def pre_parse(self):
@@ -565,7 +564,7 @@ class Parser(HTMLParserBase):
         soup.html['xmlns'] = NS.xhtml
 
         # ancient browsers didn't understand stylesheets, so xml comments were used to hide the
-        # style text. Our CSS parser is too modern to remember this, it seems. 
+        # style text. Our CSS parser is too modern to remember this, it seems.
         # So we needed to un-comment the style text
         xmlcomment = re.compile(r'<!--(.*?)-->', re.S)
         for commented_style in soup.find_all('style', string=xmlcomment):

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -542,12 +542,15 @@ class Parser(HTMLParserBase):
 
         debug("HTMLParser.pre_parse() ...")
         if b'xmlns=' in self.bytes_content() or b'-//W3C//DTD' in self.bytes_content():
+            info('using an XML parser')
             bs_parser = 'lxml'
+            extra_params = {'exclude_encodings':["us-ascii"]}
         else:
-            info('using html5lib')
+            info('using an HTML5 parser')
             bs_parser = 'html5lib'
+            extra_params = {}
         try:
-            soup = BeautifulSoup(self.bytes_content(), bs_parser, exclude_encodings=["us-ascii"])
+            soup = BeautifulSoup(self.bytes_content(), bs_parser, **extra_params)
         except:
             critical('failed to parse %s', self.attribs.url)
             raise EbookmakerBadFileException('failed parsing')

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -87,6 +87,19 @@ def mark_soup(soup):
             return True
         divider = check_patterns(node, markers)
         if divider:
+
+            # the following mess deals with the case where the marker includes 
+            # '<span>something</span) end of marker **' (as in titles with language tags)
+            if divider.next_sibling and divider.next_sibling.name == 'span':
+                if divider.next_sibling.next_sibling and not divider.next_sibling.next_sibling.name:
+                    new_divider_string = str(divider.string + divider.next_sibling.string + 
+                                          divider.next_sibling.next_sibling.string)
+                    divider.insert_before(new_divider_string)
+                    divider = divider.previous_sibling
+                    divider.next_sibling.extract()
+                    divider.next_sibling.extract()
+                    divider.next_sibling.extract()
+
             # first, copy the Node - it contains the divider
             node_for_divider = copy.copy(node)
             divider_copy = check_patterns(node_for_divider, markers)

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -28,6 +28,13 @@ def pgheader(dc):
             return ''
         return f"<p style='display:block; margin-top:1em; margin-bottom:1em; margin-left:2em; text-indent:-2em'><strong>{key}</strong>: {html.escape(val)}</p>"
 
+    def dcauthlist(dc):
+        cre_list = ''
+        for creator in dc.authors:
+            print(f'{creator.role} : {creator.name}')
+            cre_list += pstyle(creator.role, dc.make_pretty_name(creator.name)) + '\n'
+        return cre_list
+
     language_list = []
     lang = ''
     for language in dc.languages:
@@ -48,7 +55,7 @@ This ebook is for the use of anyone anywhere in the United States and most other
     <div class="container" id="pg-machine-header">
         {pstyle('Title', dc.title_no_subtitle)}
         {pstyle('Subtitle', dc.subtitle)}
-        {pstyle('Author', dc.authors_short())}
+        {dcauthlist(dc)}
         {pstyle('Release Date', 
             f'{dc.release_date.strftime(hr_format)} [EBook #{dc.project_gutenberg_id}]')}
         {pstyle('Language', ', '.join(language_list))}

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -52,7 +52,7 @@ This ebook is for the use of anyone anywhere in the United States and most other
         {pstyle('Release Date', 
             f'{dc.release_date.strftime(hr_format)} [EBook #{dc.project_gutenberg_id}]')}
         {pstyle('Language', ', '.join(language_list))}
-        {pstyle('Original Publication', str(dc.pubinfo))}
+        {pstyle('Original Publication', dc.pubinfo.marc())}
         {pstyle('Credits', dc.credit)}
     </div>
     <div class="vspace" style="height: 2em"><br /></div>

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -31,7 +31,6 @@ def pgheader(dc):
     def dcauthlist(dc):
         cre_list = ''
         for creator in dc.authors:
-            print(f'{creator.role} : {creator.name}')
             cre_list += pstyle(creator.role, dc.make_pretty_name(creator.name)) + '\n'
         return cre_list
 


### PR DESCRIPTION
- in generated header, use same method as Autocat3 for rendering PubInfo -
- in generated header, render each creator on a separate line
- don't set exclude_encodings param for html5lib parser
- improve info log message for parser selection
- header identification was messed up by language tags in the marker. removed them
- MIN_CHUNK_SIZE reduced from 1024 bytes to 256 bytes. fixes #147
- update to libgutenberg 0.10.13 to recognize plural creator roles in metadata header