### PR TITLE
include an NCX file #167

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@
 - only try to add credit from text if it's not empty
 - add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
 - don't qualify heading elements - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
-
+- include an NCX file to improve compatibility with sideloaded kobo/nook #167
+- remove public identifier from NCX file for EPUB2 - causes validation error for EPUB3
 
 
 0.12.29 February 15,2023

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -424,7 +424,6 @@ class TocNCX(object):
 
         toc_ncx = "%s\n\n%s" % (gg.XML_DECLARATION,
                                 etree.tostring(ncx,
-                                               doctype=gg.NCX_DOCTYPE,
                                                encoding=str,
                                                pretty_print=True))
         if options.verbose >= 3:


### PR DESCRIPTION
Testing indicates that adding the ncx file enables the epub3 file to be used on kobo and nook when sideloaded. Previously there was no TOC on these devices. HOWEVER, the kobo renderer (the good one) is not invoked, so the presentation on kobo  has the same problems that we observe on ADE. More testing is needed to determine whether we should recommend our EPUB2 files for Kobo, at least until the issue is addressed on their end.

Problems rendering the ebook html on sideloaded Kobo (as opposed to problems with other EPUB affordances) should NOT be considered when optimizing or enhancing our EPUB3 files.