### PR TITLE
add ncx to epub3 ...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.30
 - only try to add credit from text if it's not empty
+- add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
 
 
 0.12.29 February 15,2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.28 February 15,2023
+0.12.29 February 15,2023
 - the boilerplate header and footer has been refactored to move css styling to a stylesheet.
 - css styling for boilerplate header and footer revised to better match current submission style
 - metadata listing revised to better match current submission style
@@ -12,6 +12,8 @@
 - 'most recently updated' in header is now taken from the file modification date for the source file. when run from Ebookconverter, the file.modified value from the database is used.
 - for EPUB2, HTML5 elements such as `figure` are converted to `div` with a class corresponding to the name of the replaced class. Since the default style for `figure` is different than for `div` some CSS is inserted to change the default style. With this version, that style is now inserted at the beginning of the `head` element rather than at the end so that it is easier to override with css from the source file. fixes #151
 - display of original publication data is cleaned up
+- text added to credit from parsed html is logged to facilitate moving it to the db.
+
 
 0.12.25 January 1, 2023
 - forgot to strip marc subfields in pubinfo

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.30
+- only try to add credit from text if it's not empty
+
+
 0.12.29 February 15,2023
 - the boilerplate header and footer has been refactored to move css styling to a stylesheet.
 - css styling for boilerplate header and footer revised to better match current submission style

--- a/CHANGES
+++ b/CHANGES
@@ -1,13 +1,17 @@
-0.12.30
+0.12.30 March 8, 2013
+Note about side-loading files on Kobo devices.
+An issue with side-loading files onto Kobo devices causes the wrong rendering engine to be used for our EPUB3 files, resulting in (among other things), the absence of a TOC for the book. This version of ebookmaker adds an EPUB2-style table of contents in the EPUB3 files to mitigate this issue, as well as to improve compatibility of our EPUB3 files on older devices, such as Nook. This is common practice in the ebook industry. We will continue to produce EPUB2 files, which often render better on older devices, as well as on the older Kobo rendering engine currently invoked for side-loaded books. Kobo is aware of the issue with side-loaded EPUB3, and we expect that the issue will eventually be fixed. In the meantime, Kobo rendering of EPUB3 should NOT be considered when authoring new HTML5 books.
+
+- include an NCX toc file to improve EPUB3 compatibility with side-loaded kobo/older devices #167
+- remove public identifier from NCX files (including EPUB2) - causes validation error for EPUB3
 - only try to add credit from text if it's not empty
-- add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
-- don't qualify heading elements - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
-- remove author from boilerplate heading #161
-- include an NCX file to improve compatibility with sideloaded kobo/nook #167
-- remove public identifier from NCX file for EPUB2 - causes validation error for EPUB3
+- improve css for h2 in pg-header with `all:inherit`. (`all:revert` is what we really want, but it's not REC yet). addresses #165
+- don't qualify heading elements in CSS - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
+- remove author from boilerplate section heading #161
+- libgutenberg 0.10.17 removes $c and $v subfield markers from titles
 
 
-0.12.29 February 15,2023
+0.12.29 February 15, 2023
 - the boilerplate header and footer has been refactored to move css styling to a stylesheet.
 - css styling for boilerplate header and footer revised to better match current submission style
 - metadata listing revised to better match current submission style

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - only try to add credit from text if it's not empty
 - add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
 - don't qualify heading elements - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
+- remove author from boilerplate heading #161
 
 
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,8 @@
 - add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
 - don't qualify heading elements - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
 - remove author from boilerplate heading #161
-
+- include an NCX file to improve compatibility with sideloaded kobo/nook #167
+- remove public identifier from NCX file for EPUB2 - causes validation error for EPUB3
 
 
 0.12.29 February 15,2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.12.30
 - only try to add credit from text if it's not empty
 - add css protection for h2 in pg-header. (all:revert is what we really want, but it's not REC yet). addresses #165
+- don't qualify heading elements - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
+
 
 
 0.12.29 February 15,2023

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.16"
+libgutenberg = ">=0.10.17"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 html5lib = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.29
+version = 0.12.30
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.28
+version = 0.12.29
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.28'
+VERSION = '0.12.29'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.29'
+VERSION = '0.12.30'
 
 if __name__ == "__main__":
  
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             'roman',
             'requests',
             'six>=1.4.1',
-            'libgutenberg[covers]>=0.10.16',
+            'libgutenberg[covers]>=0.10.17',
             'cchardet',
             'beautifulsoup4',
             'html5lib',

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.29'
+VERSION = '0.12.30'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.28'
+VERSION = '0.12.29'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/mydocutils/gutenberg/parsers/pg-footer.rst
+++ b/src/ebookmaker/mydocutils/gutenberg/parsers/pg-footer.rst
@@ -307,7 +307,7 @@ Gutenberg Literary Archive Foundation was created to provide a secure
 and permanent future for Project Gutenberg™ and future generations. To
 learn more about the Project Gutenberg Literary Archive Foundation and
 how your efforts and donations can help, see Sections 3 and 4 and the
-Foundation web page at http://www.pglaf.org .
+Foundation web page at https://www.pglaf.org .
 
 
 Section 3. Information about the Project Gutenberg Literary Archive Foundation

--- a/src/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
+++ b/src/ebookmaker/mydocutils/gutenberg/transforms/__init__.py
@@ -143,7 +143,7 @@ class VariablesTransform (docutils.transforms.Transform):
                     date = datetime.datetime.strftime (date, '%B %d, %Y')
                 except ValueError:
                     date = 'unknown date'
-                s += 'Release Date: %s [EBook #%s]\n' % (date, getone ('PG.Id', '999999'))
+                s += 'Release Date: %s [eBook #%s]\n' % (date, getone ('PG.Id', '999999'))
 
                 for item in getmany ('PG.Reposted', []):
                     try:

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -430,7 +430,6 @@ class Parser(HTMLParserBase):
 
         css_for_deprecated = ' '.join([CSS_FOR_REPLACED.get(tag, '') for tag in deprecated_used])
         if css_for_deprecated.strip():
-            print(f'css_for_deprecated: {css_for_deprecated}')
             elem = etree.Element(NS.xhtml.style)
             elem.text = css_for_deprecated
             self.xhtml.find(NS.xhtml.head).insert(1, elem) # right after charset declaration

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -424,7 +424,6 @@ class TocNCX(object):
 
         toc_ncx = "%s\n\n%s" % (gg.XML_DECLARATION,
                                 etree.tostring(ncx,
-                                               doctype=gg.NCX_DOCTYPE,
                                                encoding=str,
                                                pretty_print=True))
         if options.verbose >= 3:

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -174,9 +174,9 @@ class Writer(writers.HTMLishWriter):
         # get text after the divider, put in dc.credit if not already there
         for pre in xpath(tree, '//*[@id="pg-header"]//xhtml:pre'):
             divided = DIVIDER.split(' '.join(pre.itertext()))
-            if len(divided) > 1:
+            if len(divided) > 1 and len(divided[1].strip()) > 0:
                 job.dc.add_credit(divided[1])
-                info('Text added to Credit: %s', divided[1])
+                info('Text added to Credit: %s', divided[1].strip())
 
         body = None
         for body in xpath(tree, '//xhtml:body'):

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -176,6 +176,7 @@ class Writer(writers.HTMLishWriter):
             divided = DIVIDER.split(' '.join(pre.itertext()))
             if len(divided) > 1:
                 job.dc.add_credit(divided[1])
+                info('Text added to Credit: %s', divided[1])
 
         body = None
         for body in xpath(tree, '//xhtml:body'):

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -45,6 +45,7 @@ CSS_FOR_HEADER = '''
     text-align: center;
 }
 #pg-header h2 {
+    all: inherit;
     text-align: center;
     font-size: 110%;
 }

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -121,7 +121,7 @@ This ebook is for the use of anyone anywhere in the United States and most other
         updated = nl + f'Most recently updated: {dc.update_date.strftime(hr_format)}'
     pg_header = f'''
 <section class="pg-boilerplate pgheader" id="pg-header" xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml">
-    <h2 id='pg-header-heading'>The Project Gutenberg eBook of <span lang='{lang}' xml:lang='{lang}'>{html.escape(dc.title_no_subtitle)}</span>, by {html.escape(dc.authors_short())}</h2>
+    <h2 id='pg-header-heading'>The Project Gutenberg eBook of <span lang='{lang}' xml:lang='{lang}'>{html.escape(dc.title_no_subtitle)}</span></h2>
     <div>{rights}</div>
 
     <div class="container" id="pg-machine-header">

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -128,7 +128,7 @@ This ebook is for the use of anyone anywhere in the United States and most other
         {dcauthlist(dc)}
         </div>
         {pstyle('Release Date', 
-            f'{dc.release_date.strftime(hr_format)} [EBook #{dc.project_gutenberg_id}]' + updated)}
+            f'{dc.release_date.strftime(hr_format)} [eBook #{dc.project_gutenberg_id}]' + updated)}
         {pstyle('Language', ', '.join(language_list))}
         {pstyle('Original Publication', str(dc.pubinfo))}
         {pstyle('Credits', dc.credit)}

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -44,12 +44,13 @@ CSS_FOR_HEADER = '''
     margin-bottom: 0;
     text-align: center;
 }
-#pg-header h2 {
+#pg-header-heading {
     all: inherit;
     text-align: center;
     font-size: 110%;
 }
-#pg-footer h2 {
+#pg-footer-heading {
+    all: inherit;
     text-align: center;
     font-size: 120%;
     font-weight: normal;
@@ -120,7 +121,7 @@ This ebook is for the use of anyone anywhere in the United States and most other
         updated = nl + f'Most recently updated: {dc.update_date.strftime(hr_format)}'
     pg_header = f'''
 <section class="pg-boilerplate pgheader" id="pg-header" xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml">
-    <h2>The Project Gutenberg eBook of <span lang='{lang}' xml:lang='{lang}'>{html.escape(dc.title_no_subtitle)}</span>, by {html.escape(dc.authors_short())}</h2>
+    <h2 id='pg-header-heading'>The Project Gutenberg eBook of <span lang='{lang}' xml:lang='{lang}'>{html.escape(dc.title_no_subtitle)}</span>, by {html.escape(dc.authors_short())}</h2>
     <div>{rights}</div>
 
     <div class="container" id="pg-machine-header">
@@ -184,7 +185,7 @@ license, especially commercial redistribution.
 </div>
 
 <div id='project-gutenberg-license'>START: FULL LICENSE</div>
-<h2>THE FULL PROJECT GUTENBERG LICENSE</h2>
+<h2 id='pg-footer-heading'>THE FULL PROJECT GUTENBERG LICENSE</h2>
 <div class='agate'>PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK</div>
 
 <div>


### PR DESCRIPTION
0.12.30 March 8, 2013
Note about side-loading files on Kobo devices.
An issue with side-loading files onto Kobo devices causes the wrong rendering engine to be used for our EPUB3 files, resulting in (among other things), the absence of a TOC for the book. This version of ebookmaker adds an EPUB2-style table of contents in the EPUB3 files to mitigate this issue, as well as to improve compatibility of our EPUB3 files on older devices, such as Nook. This is common practice in the ebook industry. We will continue to produce EPUB2 files, which often render better on older devices, as well as on the older Kobo rendering engine currently invoked for side-loaded books. Kobo is aware of the issue with side-loaded EPUB3, and we expect that the issue will eventually be fixed. In the meantime, Kobo rendering of EPUB3 should NOT be considered when authoring new HTML5 books.

- include an NCX toc file to improve EPUB3 compatibility with side-loaded kobo/older devices #167
- remove public identifier from NCX files (including EPUB2) - causes validation error for EPUB3
- only try to add credit from text if it's not empty
- improve css for h2 in pg-header with `all:inherit`. (`all:revert` is what we really want, but it's not REC yet). addresses #165
- don't qualify heading elements in CSS - use ids instead. https://github.com/CSSLint/csslint/wiki/Disallow-qualified-headings
- remove author from boilerplate section heading #161
- libgutenberg 0.10.17 removes $c and $v subfield markers from titles
