### PR TITLE
0.12.37 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
-0.12.37 November xx, 2023
+0.12.37 December xx, 2023
 - added `bgsound` to list of removed elements
 - added 'initial` as an allowed value for the CSS properties `display`, `margin-*`, `font-*`, `text-*`, and  `padding-*`. This has been part of W3C REC for over 2 years and is primarily useful for reproducing the behavior of the deprecated HTML4 align attribute in HTML5. 
 - Improved rendering of tables with respect to the deprecated `align` attribute.
 - added handling for the deprecated `color` attribute on `hr` elements.
-- updates pg urls in the backfile to https, updates links to html4 files to html5 files. fixed #194
+- updates pg urls in the backfile to https, updates links to html4 files to html5 files. fixed #194 
+- fixes bug where gif files are converted to png, but the manifest gives them the wrong mediatype. Fixes #207.
 
 
 0.12.36 September 20, 2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.36 September xx, 2023
+- Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs.
+
 0.12.35 August 10, 2023
 - fixed crash when END sentinel is on the last line
 - turned on the SMALLPRINT_MARKERS

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.36 September xx, 2023
 - Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs.
+- ebook number on Logger is set even if parse fails.
 
 0.12.35 August 10, 2023
 - fixed crash when END sentinel is on the last line

--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@
 - added 'initial` as an allowed value for the CSS properties `display`, `margin-*`, `font-*`, `text-*`, and  `padding-*`. This has been part of W3C REC for over 2 years and is primarily useful for reproducing the behavior of the deprecated HTML4 align attribute in HTML5. 
 - Improved rendering of tables with respect to the deprecated `align` attribute.
 - added handling for the deprecated `color` attribute on `hr` elements.
-
+- updates pg urls in the backfile to https, updates links to html4 files to html5 files. fixed #194
 
 
 0.12.36 September 20, 2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
-0.12.36 September xx, 2023
-- Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs.
+0.12.36 September 20, 2023
+Nothing in this release should affect usage without Ebookconverter (e.g. Online Ebookmaker).
+- Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs. RDF files can now be made for "books" that aren't books, such as data files, audio files, etc.
 - ebook number on Logger is set even if parse fails.
 
 0.12.35 August 10, 2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.12.37 November xx, 2023
+- added `bgsound` to list of removed elements
+- added 'initial` as an allowed value for the CSS properties `display`, `margin-*`, `font-*`, `text-*`, and  `padding-*`. This has been part of W3C REC for over 2 years and is primarily useful for reproducing the behavior of the deprecated HTML4 align attribute in HTML5. 
+- Improved rendering of tables with respect to the deprecated `align` attribute.
+- added handling for the deprecated `color` attribute on `hr` elements.
+
+
+
 0.12.36 September 20, 2023
 Nothing in this release should affect usage without Ebookconverter (e.g. Online Ebookmaker).
 - Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs. RDF files can now be made for "books" that aren't books, such as data files, audio files, etc.

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,11 @@
-0.12.37 December xx, 2023
+0.12.37 December 7, 2023
 - added `bgsound` to list of removed elements
 - added 'initial` as an allowed value for the CSS properties `display`, `margin-*`, `font-*`, `text-*`, and  `padding-*`. This has been part of W3C REC for over 2 years and is primarily useful for reproducing the behavior of the deprecated HTML4 align attribute in HTML5. 
 - Improved rendering of tables with respect to the deprecated `align` attribute.
 - added handling for the deprecated `color` attribute on `hr` elements.
 - updates pg urls in the backfile to https, updates links to html4 files to html5 files. fixed #194 
-- fixes bug where gif files are converted to png, but the manifest gives them the wrong mediatype. Fixes #207.
+- fixes #207 bug where gif files are converted to png, but the manifest gives them the wrong mediatype.
+- libgutenberg 0.10.19
 
 
 0.12.36 September 20, 2023

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.17"
+libgutenberg = ">=0.10.19"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 html5lib = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.35
+version = 0.12.36
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.36
+version = 0.12.37
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.36'
+VERSION = '0.12.37'
 
 if __name__ == "__main__":
  
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             'roman',
             'requests',
             'six>=1.4.1',
-            'libgutenberg[covers]>=0.10.17',
+            'libgutenberg[covers]>=0.10.19',
             'cchardet',
             'beautifulsoup4',
             'html5lib',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.35'
+VERSION = '0.12.36'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -227,12 +227,14 @@ def get_dc(job):
         debug("No RST header found.")
         try:
             dc.load_from_parser(parser)
-        except (ValueError, AttributeError, UnicodeError):
+        except (ValueError, AttributeError, UnicodeError) as pe:
             debug("No HTML header found.")
+            debug(pe)
             try:
                 dc.load_from_pgheader(parser.unicode_content())
-            except (ValueError, UnicodeError):
+            except (ValueError, UnicodeError) as e:
                 debug("No PG header found.")
+                debug(e)                
 
     dc.source = parser.attribs.url
     dc.title = options.title or dc.title or 'NA'

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -200,12 +200,14 @@ def generate_cover(dir, dc):
 
 def get_dc(job):
     """ Get DC for book. """
-    url = job.url
-    parser = ParserFactory.ParserFactory.create(url)
-    try:
-        parser.parse()
-    except AttributeError as e:
-        raise Exception(f'the file {job.url} could not be found or was unparsable')
+    if job.url:
+        url = job.url
+        parser = ParserFactory.ParserFactory.create(url)
+        try:
+            parser.parse()
+        except AttributeError as e:
+            raise Exception(f'the file {job.url} could not be found or was unparsable')
+
     if options.is_job_queue:
         dc = PGDCObject()
         dc.load_from_database(job.ebook)

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -599,6 +599,7 @@ def main():
                 dc.session.close()
                 dc.session = None # probably overkill
         except Exception as e:
+            Logger.ebook = job.ebook
             critical('Job failed for type %s from %s', job.type, job.url)
             exception(e)
             continue

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.35'
+VERSION = '0.12.36'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.36'
+VERSION = '0.12.37'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/CSSParser.py
+++ b/src/ebookmaker/parsers/CSSParser.py
@@ -36,8 +36,32 @@ PG_CSS_PROFILE = (
         'speak': r'auto|never|always',
         'speak-as': 'normal|spell-out|digits|literal-punctuation|no-punctuation',
         'all': 'initial|inherit|unset',
+
         # added to update css fonts level 3
-        'font-variant-numeric': r'normal|{font-variant-attrs}(\s+{font-variant-attrs})*'
+        'font-variant-numeric': r'normal|{font-variant-attrs}(\s+{font-variant-attrs})*',
+
+        # (partial) update to CSS Cascading and Inheritance Level 3
+        'display': 'initial',
+        'font-family': 'initial',
+        'font-size': 'initial',
+        'font-style': 'initial',
+        'font-variant':'initial',
+        'font-weight': 'initial',
+        'font': 'initial',
+        'margin-right': 'initial',
+        'margin-left': 'initial',
+        'margin-top': 'initial',
+        'margin-bottom': 'initial',
+        'margin': 'initial',
+        'padding-top': 'initial',
+        'padding-right': 'initial',
+        'padding-bottom': 'initial',
+        'padding-left': 'initial',
+        'padding': 'initial',
+        'text-align': 'initial',
+        'text-decoration': 'initial',
+        'text-indent': 'initial',
+        'text-transform': 'initial',
     },
     {
         'numeric-figure-values': 'lining-nums|oldstyle-nums',

--- a/src/ebookmaker/parsers/ImageParser.py
+++ b/src/ebookmaker/parsers/ImageParser.py
@@ -25,11 +25,14 @@ from libgutenberg.Logger import debug, error
 from libgutenberg.MediaTypes import mediatypes as mt
 from ebookmaker.parsers import ParserBase
 from ebookmaker.ParserFactory import ParserFactory
+from . import ParserAttributes
 
 # works around problems with bad checksums in a small number of png files
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 mediatypes = (mt.jpeg, mt.png, mt.gif, mt.svg)
+
+
 
 class Parser(ParserBase):
     """Parse an image.
@@ -86,6 +89,9 @@ class Parser(ParserBase):
                 format_ = output_format
             if format_ == 'gif':
                 format_ = 'png'
+                self.attribs.url +=  '.png'
+                self.attribs.orig_mediatype = self.attribs.mediatype
+                self.attribs.mediatype = ParserAttributes.HeaderElement(mt.png)
             if format_ == 'jpeg' and unsized_image.mode.lower() not in ('rgb', 'l'):
                 unsized_image = unsized_image.convert('RGB')
 

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -93,7 +93,11 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
   </body>
 </html>"""
 
+RE_PG_OLD_HOST = re.compile(r'http://(www\.)?gutenberg\.org')
+RE_PG_HTML_URL = re.compile(r'([^a-zA-Z0-9./?=_%:-])https://(www\.)?gutenberg\.org/files/(\d+)/\3-h/\3-h\.htm([^a-zA-Z0-9./?=_%:-])')
+REPL_PG_HTML5_URL = r'\g<1>https://www.gutenberg.org/cache/epub/\g<3>/pg\g<3>-images.html\g<4>'
 # exported
+
 em = ElementMaker(makeelement=lxml.html.xhtml_parser.makeelement,
                   namespace=str(NS.xhtml),
                   nsmap={None: str(NS.xhtml)})
@@ -113,6 +117,9 @@ def webify_url(url):
         url = url[1:]
     return 'file:///' + url
 
+def update_urls(text):
+    text = RE_PG_OLD_HOST.sub('https://www.gutenberg.org', text)
+    return RE_PG_HTML_URL.sub(REPL_PG_HTML5_URL, text)
 
 
 class ParserAttributes(object): # pylint: disable=too-few-public-methods
@@ -281,6 +288,8 @@ class ParserBase(object):
             # normalize line-endings
             if '\r' in data or '\u2028' in data:
                 data = '\n'.join(data.splitlines())
+            data = update_urls(data)
+
             self.unicode_buffer = data
 
         return self.unicode_buffer

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -93,7 +93,7 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
   </body>
 </html>"""
 
-RE_PG_OLD_HOST = re.compile(r'http://(www\.)?gutenberg\.org')
+RE_PG_OLD_HOST = re.compile(r'http://(www\.)?gutenberg\.(org|net)/')
 RE_PG_HTML_URL = re.compile(r'([^a-zA-Z0-9./?=_%:-])https://(www\.)?gutenberg\.org/files/(\d+)/\3-h/\3-h\.htm([^a-zA-Z0-9./?=_%:-])')
 REPL_PG_HTML5_URL = r'\g<1>https://www.gutenberg.org/cache/epub/\g<3>/pg\g<3>-images.html\g<4>'
 # exported
@@ -118,7 +118,7 @@ def webify_url(url):
     return 'file:///' + url
 
 def update_urls(text):
-    text = RE_PG_OLD_HOST.sub('https://www.gutenberg.org', text)
+    text = RE_PG_OLD_HOST.sub('https://www.gutenberg.org/', text)
     return RE_PG_HTML_URL.sub(REPL_PG_HTML5_URL, text)
 
 


### PR DESCRIPTION
0.12.37 December 7, 2023
- added `bgsound` to list of removed elements
- added 'initial` as an allowed value for the CSS properties `display`, `margin-*`, `font-*`, `text-*`, and  `padding-*`. This has been part of W3C REC for over 2 years and is primarily useful for reproducing the behavior of the deprecated HTML4 align attribute in HTML5. 
- Improved rendering of tables with respect to the deprecated `align` attribute.
- added handling for the deprecated `color` attribute on `hr` elements.
- updates pg urls in the backfile to https, updates links to html4 files to html5 files. fixed #194 
- fixes #207 bug where gif files are converted to png, but the manifest gives them the wrong mediatype.
- libgutenberg 0.10.19

0.12.36 September 20, 2023
Nothing in this release should affect usage without Ebookconverter (e.g. Online Ebookmaker).
- Ebookmaker no longer needs a parsable source file to use metadata-only writers. So, RDF, and QRcodes, and posts to Mastodon and Facebook, can be made using only the database. This change should also save execution time, as parsing of the source files is no longer done for each of these outputs. RDF files can now be made for "books" that aren't books, such as data files, audio files, etc.
- ebook number on Logger is set even if parse fails.