### PR TITLE
0.12.39

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.
 - for EPUB2, added a deprecation for `u` elements. fixes #210
 - fixed multiline handling of MARKER_END in text boilerplate. fixes #209
+- libgutenberg 0.10.20
 
 
 0.12.38 December 8, 2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 0.12.39 January 31, 2024
 - fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.
+- for EPUB2, added a deprecation for `u` elements. fixes #210
+- fixed multiline handling of MARKER_END in text boilerplate. fixes #209
 
 
 0.12.38 December 8, 2023

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.39 January 31, 2024
+- fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.
+
+
 0.12.38 December 8, 2023
 - fixed reversion where adding display: initial over-wrote the addition of display:flex
 

--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ libgutenberg = ">=0.10.19"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 html5lib = "*"
-ebookmaker = {editable = true, path = "."}
+ebookmaker = {file = ".", editable = true}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.38
+version = 0.12.39
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.38'
+VERSION = '0.12.39'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             'roman',
             'requests',
             'six>=1.4.1',
-            'libgutenberg[covers]>=0.10.19',
+            'libgutenberg[covers]>=0.10.20',
             'cchardet',
             'beautifulsoup4',
             'html5lib',

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.38'
+VERSION = '0.12.39'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -51,7 +51,7 @@ SMALLPRINT_MARKERS = [
     re.compile(r"\**END THE SMALL PRINT", re.I),
     re.compile(r"\** ?These \w+ Were Prepared By Thousands", re.I),
 ]
-MARKER_END = re.compile(r"\**")
+MARKER_END = re.compile(r"\*+")
 
 def prune(root, divider, after=True):
     ''' prune parts of the root element before or after a divider  '''
@@ -153,18 +153,11 @@ def strip_headers_from_txt(text):
         for marker in markers:
             divider = marker.search(text)
             if divider:
-                sections = text.split(divider.group(0))
-                if len(sections) == 2:
-                    (before, after) = sections
-                    if MARKER_END.search(after.split('\n')[0]):
-                        # remove first line of after
-                        if len(after.split('\n')) > 1:
-                            after = after.split('\n', 1)[1]
-                        else:
-                            after = ''
-                else:
-                    before = ' '.join(sections[0:-1])
-                    after = sections[-1]
+                before, after = text.split(divider.group(0), maxsplit=1)
+                after_sections = MARKER_END.split(after, maxsplit=1)
+                if len(after_sections) == 2 and len(after_sections[0]) < 500:
+                    after = after_sections[1]
+                
                 return before, divider.group(0), after
         return  text, None, text
     header_text, divider, text = markers_split(text, TOP_MARKERS + SMALLPRINT_MARKERS)

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -414,7 +414,7 @@ class TocNCX(object):
 
         # remove gaps in playOrder
         play_orders = list(self.play_orders)
-        play_orders.sort()
+        play_orders.sort(key=lambda s: int(s))
         for np in xpath(ncx, '//ncx:*[@playOrder]'):
             po = np.attrib['playOrder']
             np.attrib['playOrder'] = str(play_orders.index(po) + 1)

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -100,6 +100,9 @@ h2 {
 div.figcenter span.caption {
    display: block;
    }
+span.u {
+    text-decoration: underline;
+}
 .pgmonospaced {
    font-family: monospace;
    font-size: 0.9em
@@ -1042,11 +1045,19 @@ class Writer(writers.HTMLishWriter):
             for elem in xpath(xhtml, f"//xhtml:{tag}[@{attr}]"):
                 del elem.attrib[attr]
 
+        # replace html5 block tags
         usedtags = set()
         for newtag in ['article', 'figcaption', 'figure', 'footer', 'header', 'section']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):
                 usedtags.add(newtag)
                 tag.tag = NS.xhtml.div
+                writers.HTMLWriter.add_class(tag, newtag)
+
+        # replace html5 inline tags
+        for newtag in ['u']:
+            for tag in xpath(xhtml, f'//xhtml:{newtag}'):
+                usedtags.add(newtag)
+                tag.tag = NS.xhtml.span
                 writers.HTMLWriter.add_class(tag, newtag)
 
 

--- a/tests/files/43172/43172-h/43172-h.htm
+++ b/tests/files/43172/43172-h/43172-h.htm
@@ -264,9 +264,9 @@ evidentemente l'effetto del ribrezzo pel nuovo.
 Quest'odio per il nuovo, che si osserva nei
 fanciulli, si nota a maggior ragione nei popoli
 selvaggi, la cui debolezza psichica fa sì che una
-volta assimilate alcune sensazioni, impediscano
+<u>volta assimilate alcune sensazioni, impediscano
 l'assimilazione di altre, massime se la differenza
-sia viva, e non vi sia un passaggio, una sfumatura
+sia viva, e non vi sia un passaggio, una sfumatura</u>
 che le colleghi; così nelle lingue primitive
 <i>elefante</i> è <i>bue con i denti</i>; nella chinese i cavalli
 sono <i>cani grandi</i>; nel sanscritto per esprimere


### PR DESCRIPTION
- fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.
- for EPUB2, added a deprecation for `u` elements. fixes #210
- fixed multiline handling of MARKER_END in text boilerplate. fixes #209
- libgutenberg 0.10.20
