### PR TITLE
0.12.40

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.12.40 February 9, 2024
+- fixed an issue parsing large text files. "The Entire Project Gutenberg Works of Mark Twain" was 1.2M.
+- fixed an issue detecting multiline boilerplate markers.
+- added an id 'pg-title-no-subtitle' to a span containing dc.title_no_subtitle
+
 0.12.39 January 31, 2024
 - fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.
 - for EPUB2, added a deprecation for `u` elements. fixes #210

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.39
+version = 0.12.40
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.39'
+VERSION = '0.12.40'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.39'
+VERSION = '0.12.40'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/GutenbergTextParser.py
+++ b/src/ebookmaker/parsers/GutenbergTextParser.py
@@ -676,7 +676,7 @@ class Parser(HTMLParserBase):
         )
 
         for body in xpath(self.xhtml, '//xhtml:body'):
-            xhtmlparser = lxml.html.XHTMLParser()
+            xhtmlparser = lxml.html.XHTMLParser(huge_tree=True)
             body.append(etree.fromstring(pg_header, xhtmlparser))
             for par in self.pars:
                 p = etree.fromstring(self.ship_out(par), xhtmlparser)

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -38,18 +38,18 @@ from libgutenberg.Logger import critical, info, debug, warning, error
 
 
 TOP_MARKERS = [
-    re.compile(r"\*+ ?START OF TH(E|IS) PROJECT GUTENBERG", re.I),
+    re.compile(r"\*+ ?START\s+OF\s+TH(E|IS)\s+PROJECT\s+GUTENBERG", re.I),
 ]
 BOTTOM_MARKERS = [
-    re.compile(r"\** ?END OF TH(E|IS) PROJECT GUTENBERG", re.I),
-    re.compile(r"\** ?Ende dieses Projekt Gutenberg", re.I),
-    re.compile(r"\** ?END OF PROJECT GUTENBERG", re.I),
-    re.compile(r"\** ?End of the Project Gutenberg", re.I),
+    re.compile(r"\** ?END\s+OF\s+TH(E|IS)\s+PROJECT\s+GUTENBERG", re.I),
+    re.compile(r"\** ?Ende\w*dieses\w*Projekt\w*Gutenberg", re.I),
+    re.compile(r"\** ?END\s+OF\s+PROJECT\s+GUTENBERG", re.I),
+    re.compile(r"\** ?End\s+of\s+the\s+Project\s+Gutenberg", re.I),
 ]
 SMALLPRINT_MARKERS = [
-    re.compile(r"\** ?END\*? ?THE SMALL PRINT", re.I),
-    re.compile(r"\**END THE SMALL PRINT", re.I),
-    re.compile(r"\** ?These \w+ Were Prepared By Thousands", re.I),
+    re.compile(r"\** ?END\*? ?THE\s+SMALL\s+PRINT", re.I),
+    re.compile(r"\**END\s+THE\s+SMALL\s+PRINT", re.I),
+    re.compile(r"\** ?These\s+\w+\s+Were\s+Prepared\s+By\s+Thousands", re.I),
 ]
 MARKER_END = re.compile(r"\*+")
 

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -67,7 +67,7 @@ def pgheader(dc):
     pg_header = '<section class="pg-boilerplate pgheader" id="pg-header" xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml">'
     pg_header += "<h2 id='pg-header-heading' title=''>"
     pg_header += 'The Project Gutenberg eBook of '
-    pg_header += f'''<span lang='{lang}' xml:lang='{lang}'>{html.escape(dc.title_no_subtitle)}</span></h2>
+    pg_header += f'''<span lang='{lang}' xml:lang='{lang}' id='pg-title-no-subtitle'>{html.escape(dc.title_no_subtitle)}</span></h2>
     {rights}<div class='container' id='pg-machine-header'>{pstyle('Title', dc.title_no_subtitle)}{pstyle('Previous', dc.subtitle) if dc.subtitle  else ''}
 <div id='pg-header-authlist'>{dcauthlist(dc)}</div>
 {pstyle('Release Date', 


### PR DESCRIPTION
0.12.40 February 9, 2024
- fixed an issue parsing large text files. "The Entire Project Gutenberg Works of Mark Twain" was 1.2M.
- fixed an issue detecting multiline boilerplate markers.
- added an id 'pg-title-no-subtitle' to a span containing dc.title_no_subtitle

