### PR TITLE
fix rst -> epub3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.42 April 01, 2024
+- fixed rst -> epub3 conversion
+
 0.12.41 March 01, 2024
 - clean up txt boilerplate. fixes easy parts of #220
 - refactor `enclose_text()` to properly deal with html4 transitional files

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.41
+version = 0.12.42
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.41'
+VERSION = '0.12.42'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.41'
+VERSION = '0.12.42'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -656,6 +656,7 @@ class Writer(EpubWriter.Writer):
 
                     if hasattr(p, 'rst2epub2'):
                         xhtml = p.rst2epub2(job)
+                        xhtml = copy.deepcopy(xhtml)
 
                         if options.verbose >= 2:
                             # write html to disk for debugging


### PR DESCRIPTION
somehow doing a deepcopy of the the transformed xhtml fixes a problem where the chunker can't deal with self-closed tags. The was already being done for the EPUB2 output.