### PR TITLE
0.12.43

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.12.43 May xx, 2024
+- fixed chunker bugs:
+    - no longer emits empty chunks (was happening with large child elements of body) #224
+    - no longer splits elements in NEVER_SPLIT list when they are only children. #226
+
 0.12.42 April 01, 2024
 - fixed rst -> epub3 conversion
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,14 @@
-0.12.43 May xx, 2024
+0.12.43 May 22, 2024
 - fixed chunker bugs:
     - no longer emits empty chunks (was happening with large child elements of body) #224
     - no longer splits elements in NEVER_SPLIT list when they are only children. #226
 - fix missing empty line in txt output for copyrighted books #222
 - made copyright addition in header/footer case-insensitive
 - adds NFC unicode normalization to text parser #218
+- libgutenberg 0.10.5
+    - don't strip periods from title_no_subtitle
+    - The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
+    - fixed a reversion in 0.10.10 that made author name matching case sensitive.
 
 
 0.12.42 April 01, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
     - no longer splits elements in NEVER_SPLIT list when they are only children. #226
 - fix missing empty line in txt output for copyrighted books #222
 - made copyright addition in header/footer case-insensitive
+- adds NFC unicode normalization to text parser #218
 
 
 0.12.42 April 01, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,8 @@
 - libgutenberg 0.10.5
     - don't strip periods from title_no_subtitle
     - The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
-    - fixed a reversion in 0.10.10 that made author name matching case sensitive.
+    - fixed a reversion in 0.10.10 that made author name matching case sensitive.   
+- get ebook number from filename if parse fails #225 
 
 
 0.12.42 April 01, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,13 @@
 - fixed chunker bugs:
     - no longer emits empty chunks (was happening with large child elements of body) #224
     - no longer splits elements in NEVER_SPLIT list when they are only children. #226
+- fix missing empty line in txt output for copyrighted books #222
+- made copyright addition in header/footer case-insensitive
+
 
 0.12.42 April 01, 2024
 - fixed rst -> epub3 conversion
+
 
 0.12.41 March 01, 2024
 - clean up txt boilerplate. fixes easy parts of #220
@@ -17,6 +21,7 @@
 - fixed an issue parsing large text files. "The Entire Project Gutenberg Works of Mark Twain" was 1.2M.
 - fixed an issue detecting multiline boilerplate markers.
 - added an id 'pg-title-no-subtitle' to a span containing dc.title_no_subtitle
+
 
 0.12.39 January 31, 2024
 - fixed an EPUB3 problem affecting kobo reader when a book has more than 10 chapters - read order was being sorted as a string.

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = ">=0.10.19"
+libgutenberg = "==0.10.25"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 html5lib = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.42
+version = 0.12.43
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.42'
+VERSION = '0.12.43'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -109,6 +109,13 @@ FILENAMES = {
 
 COVERPAGE_MIN_AREA = 200 * 200
 
+def id_from_filename(fn):
+    idmatch = re.search(r'\d+', fn)
+    if idmatch:
+        return int(idmatch.group(0))
+    else:
+        return 0
+
 def make_output_filename(type_, dc):
     """ Make a suitable filename for output type. """
     name_token = options.outputfile or dc.project_gutenberg_id
@@ -206,6 +213,7 @@ def get_dc(job):
         try:
             parser.parse()
         except AttributeError as e:
+            critical('the file {job.url} could not be found or was unparsable')
             raise Exception(f'the file {job.url} could not be found or was unparsable')
 
     if options.is_job_queue:
@@ -601,8 +609,8 @@ def main():
                 dc.session.close()
                 dc.session = None # probably overkill
         except Exception as e:
-            Logger.ebook = job.ebook
-            critical('Job failed for type %s from %s', job.type, job.url)
+            Logger.ebook = job.ebook or id_from_filename(job.url)
+            critical(f'Job #{Logger.ebook} failed for type {job.type} from {job.url}' )
             exception(e)
             continue
 

--- a/src/ebookmaker/HTMLChunker.py
+++ b/src/ebookmaker/HTMLChunker.py
@@ -107,7 +107,7 @@ class HTMLChunker(object):
         for c in xpath(template, '//xhtml:body'):
 
             # descend while elem has only one child
-            while len(c) == 1:
+            while len(c) == 1 and c[0].tag not in NEVER_SPLIT:
                 c = c[0]
 
             # clear children but save attributes
@@ -130,7 +130,7 @@ class HTMLChunker(object):
         self.chunk = copy.deepcopy(template)
         self.chunk_size = 0
         self.chunk_body = xpath(self.chunk, "//xhtml:body")[0]
-        while len(self.chunk_body) == 1:
+        while len(self.chunk_body) == 1 and self.chunk_body[0].tag not in NEVER_SPLIT:
             self.chunk_body = self.chunk_body[0]
         self.nosplit = False
 
@@ -180,7 +180,7 @@ class HTMLChunker(object):
         for body in xpath(tree, "//xhtml:body"):
             # we can't split a node that has only one child
             # descend while elem has only one child
-            while len(body) == 1:
+            while len(body) == 1 and body[0].tag not in NEVER_SPLIT:
                 body = body[0]
 
             debug("body tag is %s" % body.tag)

--- a/src/ebookmaker/HTMLChunker.py
+++ b/src/ebookmaker/HTMLChunker.py
@@ -165,9 +165,10 @@ class HTMLChunker(object):
         attribs.url = chunk_name
         attribs.id = chunk_id
         attribs.comment = comment
-        self.chunks.append((self.chunk, attribs) )
+        if self.chunk_size > 0:
+            self.chunks.append((self.chunk, attribs) )
 
-        debug("Adding chunk %s (%d bytes) %s" % (chunk_name, self.chunk_size, chunk_id))
+            debug("Adding chunk %s (%d bytes) %s" % (chunk_name, self.chunk_size, chunk_id))
 
 
     def split(self, tree, attribs):

--- a/src/ebookmaker/HTMLChunker.py
+++ b/src/ebookmaker/HTMLChunker.py
@@ -113,13 +113,8 @@ class HTMLChunker(object):
             # clear children but save attributes
             attributes = c.attrib.items()
             c.clear()
-            # was tentative fix for patological one-element-html case
-            # for child in c:
-            #     c.remove(child)
             for a in attributes:
                 c.set(a[0], a[1])
-
-        # debug(etree.tostring(template))
 
         return template
 

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.42'
+VERSION = '0.12.43'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -20,6 +20,7 @@ import copy
 from cherrypy.lib import httputil
 import six
 from six.moves import urllib
+import unicodedata
 
 import lxml.html
 from lxml import etree
@@ -120,7 +121,6 @@ def webify_url(url):
 def update_urls(text):
     text = RE_PG_OLD_HOST.sub('https://www.gutenberg.org/', text)
     return RE_PG_HTML_URL.sub(REPL_PG_HTML5_URL, text)
-
 
 class ParserAttributes(object): # pylint: disable=too-few-public-methods
     """ Object to hold attributes for the lifetime of a parser.
@@ -284,6 +284,9 @@ class ParserBase(object):
                     self.unicode_buffer = ''
                 else:
                     raise UnicodeError("Text in Klingon encoding ... giving up.")
+            # NFC
+            data = unicodedata.normalize('NFC', data)
+            debug('NFC normalized data')
 
             # normalize line-endings
             if '\r' in data or '\u2028' in data:

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -55,7 +55,7 @@ def pgheader(dc):
         lang = lang if lang else language.id 
         language_list.append(language.language)
 
-    if 'copyright' in dc.rights:
+    if 'copyright' in dc.rights.lower():
         rights = HEADERA.format(copyrighted=COPYRIGHTED)    
     else:
         rights = HEADERA.format(copyrighted='')
@@ -90,7 +90,7 @@ def pgheader(dc):
     
 
 def pgfooter(dc):
-    copyright_addition = COPYRIGHT_ADDITION if 'copyright' in dc.rights else ''
+    copyright_addition = COPYRIGHT_ADDITION if 'copyright' in dc.rights.lower() else ''
 
     pg_footer = f'''
 <section class="pg-boilerplate pgheader" id="pg-footer" lang='en' xml:lang='en' xmlns="http://www.w3.org/1999/xhtml">

--- a/src/ebookmaker/writers/TemplateStrings.py
+++ b/src/ebookmaker/writers/TemplateStrings.py
@@ -105,13 +105,13 @@ headera_txt = re.sub(r'<[^>]+>', '', headera)
 headera_copy_txt = re.sub(r'<[^>]+>', '', headera_copy)
 
 
-COPYRIGHT_ADDITION = '''<div>This particular work is one of the few individual works protected
+COPYRIGHT_ADDITION = '''
+<div>This particular work is one of the few individual works protected
 by copyright law in the United States and most of the remainder of the
 world, included in the Project Gutenberg collection with the
 permission of the copyright holder. Information on the copyright owner
 for this particular work and the terms of use imposed by the copyright
-holder on this work are set forth at the beginning of this work.
-</div>
+holder on this work are set forth at the beginning of this work.</div>
 '''
 
 HEADERB = '''


### PR DESCRIPTION
0.12.43 May 22, 2024
- fixed chunker bugs:
    - no longer emits empty chunks (was happening with large child elements of body) #224
    - no longer splits elements in NEVER_SPLIT list when they are only children. #226
- fix missing empty line in txt output for copyrighted books #222
- made copyright addition in header/footer case-insensitive
- adds NFC unicode normalization to text parser #218
- libgutenberg 0.10.5
    - don't strip periods from title_no_subtitle
    - The `heading` column in the database's author-book many to many table was being ignored by much of our code. The result was that multiple authors were being listed in alphabetical order. now, the heading column is used and the first sort column for the authors of a book, and the authors other than the first author are have heading=2 (instead of the default `heading=1`) set on initial metadata load. The cataloguer can reset the heading numbers, but does not wish the order of authors other than the "main" author to be tracked in the database.
    - fixed a reversion in 0.10.10 that made author name matching case sensitive.   
- get ebook number from filename if parse fails #225 
