### PR TITLE
work around validator bug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.12.46 September 20, 2024
+0.12.47 September 20, 2024
 - because of a validator bug, the W3C recommended markup for images with fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files thus declare the "presentaionn" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599
 
 0.12.45 September 18, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 0.12.47 September 20, 2024
-- because of a validator bug, the W3C recommended markup for images with fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files thus declare the "presentaionn" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599
+- because of a validator bug, the W3C recommended markup for images with `role="presentation"` fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files that use the "presentation" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599
 
 0.12.45 September 18, 2024
 - generated covers are now 1600x2400 to comply with Apple Books recommended minimum width and DP guidelines https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/Post-Processing_FAQ#Information_for_all_types_of_cover #234

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.12.46 September 20, 2024
+- because of a validator bug, the W3C recommended markup for images with fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files thus declare the "presentaionn" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599
+
 0.12.45 September 18, 2024
 - generated covers are now 1600x2400 to comply with Apple Books recommended minimum width and DP guidelines https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/Post-Processing_FAQ#Information_for_all_types_of_cover #234
 - added accessibility metadata to EPUB3 content.ocf as suggested by ACE

--- a/docs/alt-text.md
+++ b/docs/alt-text.md
@@ -2,7 +2,7 @@ Ebookmaker encourages proper use of the alt attribute to make books with images 
 
 Often the `alt` attribute should be left empty:
 
-1. when the image is purely decorative or used to help with the visual presentation of text. It would be disruptive to a person using text-to-speach or a braille reader to have the image described. In such a case, add a`role` attribute with value `presentation`: `<img src="image.png" alt="" role="presentation">` and the warning message will be suppressed.
+1. when the image is purely decorative or used to help with the visual presentation of text. It would be disruptive to a person using text-to-speach or a braille reader to have the image described. In such a case, add a`role` attribute with value `presentation`: `<img src="image.png" alt="" role="presentation">` and the warning message will be suppressed. Because of a bug in the W3C HTML validator, you can also use `data-role="presentation"` so that the validator won't complain - ebookmaker will use this to produce valid html5 and epub files.
 
 2. when the image is well described by associated text. Often an image from a book will appear above a descriptive caption. For this reason, Ebookmaker will not emit a warning message if it appears inside a `<figure>` element containing a `<figcaption>`, or if the img has an `aria-labelledby` attribute: `<img src="image.png" alt="" aria-labelledby="id_for_label">` But when relying on a caption text, make sure it is describing what a sighted reader sees. Some captions comment on the image without describing it.
 
@@ -17,3 +17,5 @@ Other helpful guides:
 https://publishers.asn.au/BooksWithoutBarriers
 https://axesslab.com/alt-texts/
 https://accessibility.huit.harvard.edu/describe-content-images
+
+w3c validator bug: https://github.com/validator/validator/issues/1599

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.45
+version = 0.12.47
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.45'
+VERSION = '0.12.47'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.45'
+VERSION = '0.12.47'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -474,15 +474,22 @@ class Parser(HTMLParserBase):
                     break
         
         # process alt tags
+        # work around bug in w3c validator: 
         for elem in xpath(self.xhtml, "//xhtml:img"):
             infigure = False
             labeled = elem.get('aria-labelledby')
             if labeled and labeled in self.seen_ids:
                 continue
-            if elem.get('role') == 'presentation':
-                continue
-            alt = elem.get('alt').split('\r\n')[0]
+            alt = elem.get('alt', '').split('\r\n')[0]
             if not alt:
+                if elem.get('role') == 'presentation':
+                    del elem.attrib['role']
+                    elem.attrib['alt'] = ''
+                    continue
+                # created synonym for role to work around validator bug
+                if elem.get('data-role') == 'presentation':
+                    elem.attrib['alt'] = ''
+                    continue
                 # check if it's in a figure
                 parent = elem.getparent()              
                 while parent is not None:

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -88,7 +88,7 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
   </head>
   <body>
     <div style="text-align: center">
-      <img src="{src}" alt={title} class="{wrapper_class}" />
+      <img src="{src}" alt="{title}" class="{wrapper_class}" />
       {backlink}
     </div>
   </body>

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -80,6 +80,8 @@ BOGUS_CHARSET_NAMES = {'iso-latin-1': 'iso-8859-1',
 COREATTRS = ["class", "dir", "id", "lang", "style", "title"]
 
 STYLE_LINK = '<link href="pgepub.css" rel="stylesheet"/>'
+
+# note: title is prequoted
 IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
@@ -88,7 +90,7 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>{doctype}
   </head>
   <body>
     <div style="text-align: center">
-      <img src="{src}" alt="{title}" class="{wrapper_class}" />
+      <img src="{src}" alt={title} class="{wrapper_class}" />
       {backlink}
     </div>
   </body>


### PR DESCRIPTION
0.12.47 September 20, 2024
- because of a validator bug, the W3C recommended markup for images with `role="presentation"` fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files that use the "presentation" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599