### PR TITLE
bugfixes, a11y improvements, langs, ruby, pubyear

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,15 +1,16 @@
-0.12.48 wip
-- improve alt-text logging, refactor filesdir
+0.12.48 December 30, 2024
+- the existing warnings for empty alt attributes proved to be somewhat counterproductive. The physician's motto "first, do no harm" is wise. Empty alt attributes are in many cases the correct solution for accessibility, but there are many commonly used entries that are much worse for accessibility. Based on a census of actual alt text entries, the following changes are being made:
+    - empty WARNING  for empty strings in alt attributes is changed to an INFO message. (total 179,161 occurrences)
+    - common decorative image indicators in alt text (such as "decoration") are now removed from alt text with a WARNING and data-role="presentation" is added. (total 6,288 occurrences)
+    - common inappropriate alt text entries (such as "[image unavailable.]") are now replaced with "" and an ERROR message. (total 16420 occurrences). fixes #239
+    - improved alt-text logging, refactored filesdir
 - fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
-- added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
+- added experimental alt-text insertion capability in HTMLParser. It checks for a json file of contributed alt text in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
 - added gd, nv, and oj to the 3 to 2 language table, fixing #243
-- csv escape the [ALTTEXT] log entries. fixes #246
-- empty string in alt text WARNING changed to INFO. (total 179,161 occurrences)
-- common decorative image indicators now removed from alt text with a WARNING and data-role="presentation" added. (total 6,288 occurrences)
-- common inappropriate alt text messages now replaced with "" and an ERROR message. (total 16420 occurrences)
 - added removal for aria-* and role attributes for EPUB2 files.
 - restore role attribute from data-role attributes for EPUB3 files since the EPUB validator doesn't have the html5 validator's bug.
-
+- (via libgutenberg) fixed bug that caused original publication year to be omitted for pubinfo strings. Fixes #245
+- replace ruby markup for EPUB2, rb element for HTML5. (`ruby`, `rt` and `rp` are not allowed in EPUB2, and `rb`, "ruby base", is deprecated in HTML5) Fixes #244.
 
 0.12.47 September 20, 2024
 - because of a validator bug, the W3C recommended markup for images with `role="presentation"` fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files that use the "presentation" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.12.48 wip
 - improve alt-text logging, refactor filesdir
+- fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@
 - added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
 - added gd, nv, and oj to the 3 to 2 language table, fixing #243
 - csv escape the [ALTTEXT] log entries. fixes #246
+- empty string in alt text WARNING changed to INFO. (total 179,161 occurrences)
+- common decorative image indicators now removed from alt text with a WARNING and data-role="presentation" added. (total 6,288 occurrences)
+- common inappropriate alt text messages now replaced with "" and an ERROR message. (total 16420 occurrences)
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.12.48 wip
+- improve alt-text logging, refactor filesdir
+
+
 0.12.47 September 20, 2024
 - because of a validator bug, the W3C recommended markup for images with `role="presentation"` fails w3c validation. We have made `data-role' a synonym for `role` in this context, allowing files that use the "presentation" role to do so without raising a validation error. https://github.com/validator/validator/issues/1599
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
 - added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
 - added gd, nv, and oj to the 3 to 2 language table, fixing #243
+- csv escape the [ALTTEXT] log entries. fixes #246
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - empty string in alt text WARNING changed to INFO. (total 179,161 occurrences)
 - common decorative image indicators now removed from alt text with a WARNING and data-role="presentation" added. (total 6,288 occurrences)
 - common inappropriate alt text messages now replaced with "" and an ERROR message. (total 16420 occurrences)
+- added removal for aria-* and role attributes for EPUB2 files.
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 - common decorative image indicators now removed from alt text with a WARNING and data-role="presentation" added. (total 6,288 occurrences)
 - common inappropriate alt text messages now replaced with "" and an ERROR message. (total 16420 occurrences)
 - added removal for aria-* and role attributes for EPUB2 files.
+- restore role attribute from data-role attributes for EPUB3 files since the EPUB validator doesn't have the html5 validator's bug.
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.12.48 wip
 - improve alt-text logging, refactor filesdir
 - fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
+- added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works.
 
 
 0.12.47 September 20, 2024

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 0.12.48 wip
 - improve alt-text logging, refactor filesdir
 - fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
-- added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works.
+- added alt-text insertion capability in HTMLParser. In checks for a json file in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
+- added gd, nv, and oj to the 3 to 2 language table, fixing #243
 
 
 0.12.47 September 20, 2024

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 
 [packages]
 e1839a8 = {path = ".",editable = true}
-libgutenberg = "==0.10.26"
+libgutenberg = ">=0.10.31"
 psycopg2 = "*"
 docutils = ">=0.18.1"
 html5lib = "*"

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ then:
 
 `$ pipenv install -e .`
 
-`$ python setup.py test`
+`$ python -m unittest discover`
 
-Travis-CI will run tests on branches committed in the gutenbergtools org
 
 ## Notes running Ebookmaker on Windows Machine (adapted from @windymilla)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ebookmaker
-version = 0.12.47
+version = 0.12.48
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.12.47'
+VERSION = '0.12.48'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/CommonCode.py
+++ b/src/ebookmaker/CommonCode.py
@@ -174,6 +174,19 @@ def dir_from_url(url):
 
 RE_SIMPATH = re.compile(r'^\d/')
 RE_PGNUM = re.compile(r'/(\d\d+/.*)')
+
+def filesdir():
+    if hasattr(options.config, 'FILESDIR'):
+        if not options.config.FILESDIR[-1] == '/':
+            return dir_from_url(options.config.FILESDIR + '/')
+        else:
+            return dir_from_url(options.config.FILESDIR)
+    else:
+        # use home dir
+        _filesdir = os.path.expanduser("~")
+        warning('Not configured, using %s for FILESDIR', _filesdir)
+        return _filesdir
+    
 def path_from_file(f):
     """
     In some places, we need to get a file system path from a database file object
@@ -205,15 +218,6 @@ def path_from_file(f):
         error('%s is not a string or a libgutenberg.Models.File object', f)
         return
 
-    if hasattr(options.config, 'FILESDIR'):
-        if not options.config.FILESDIR[-1] == '/':
-            filesdir = dir_from_url(options.config.FILESDIR + '/')
-        else:
-            filesdir = dir_from_url(options.config.FILESDIR)
-    else:
-        # use home dir
-        filesdir = os.path.expanduser("~")
-        warning('Not configured, using %s for FILESDIR', filesdir)
     if hasattr(options.config, 'CACHEDIR'):
         cachedir = dir_from_url(options.config.CACHEDIR)        
     else:
@@ -227,11 +231,11 @@ def path_from_file(f):
         # files directory, replace 1/2/3/1234 with files/1234
         if archive_path[0] == '0':
             # special case for single digits
-            return os.path.join(filesdir, 'files', archive_path[2:])
+            return os.path.join(filesdir(), 'files', archive_path[2:])
         else:
             pgnum = RE_PGNUM.search(archive_path)
             if pgnum:
-                return os.path.join(filesdir, 'files', pgnum.group(1))
+                return os.path.join(filesdir(), 'files', pgnum.group(1))
     # legacy pattern, shouldn't be there, but give it a try
     warning('%s is an obsolete or incomplete archive path', archive_path)
     return os.path.join('filesdir', 'dirs', archive_path)

--- a/src/ebookmaker/CommonCode.py
+++ b/src/ebookmaker/CommonCode.py
@@ -283,9 +283,10 @@ class EbookAltText:
     def get(self, img_id):
         if self._alt_map != None:
             return self._alt_map.get(img_id, '')
-            
+
+ONELINE = re.compile(r'[\r\n]+')
 def csv_escape(items):
     buf = StringIO()
     csvwriter = csv.writer(buf, dialect="excel")
-    csvwriter.writerow(items)
+    csvwriter.writerow([ONELINE.sub(' ', str(item)) for item in items])
     return buf.getvalue()

--- a/src/ebookmaker/CommonCode.py
+++ b/src/ebookmaker/CommonCode.py
@@ -11,11 +11,13 @@ Distributable under the GNU General Public License Version 3 or newer.
 Common code for EbookMaker and EbookConverter.
 
 """
+import csv
 import datetime
 import json
 import os
 import re
 
+from io import StringIO
 from six.moves import configparser
 
 from libgutenberg.CommonOptions import Options
@@ -282,5 +284,8 @@ class EbookAltText:
         if self._alt_map != None:
             return self._alt_map.get(img_id, '')
             
-
-
+def csv_escape(items):
+    buf = StringIO()
+    csvwriter = csv.writer(buf, dialect="excel")
+    csvwriter.writerow(items)
+    return buf.getvalue()

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.12.47'
+VERSION = '0.12.48'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -77,6 +77,7 @@ REPLACE_ELEMENTS = {
     'blink': 'span',
     'embed': None,
     'bgsound': None,
+    'rb': 'span',
 }
 
 DEPRECATED = {

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -23,12 +23,12 @@ from bs4 import BeautifulSoup, Comment, NavigableString, Tag
 from bs4.formatter import EntitySubstitution, HTMLFormatter
 
 
-from libgutenberg.GutenbergGlobals import NS
+from libgutenberg.GutenbergGlobals import make_url_relative, NS
 from libgutenberg.Logger import critical, info, debug, warning, error
 from libgutenberg.MediaTypes import mediatypes as mt
 
 from ebookmaker import parsers
-from ebookmaker.CommonCode import Options, EbookmakerBadFileException
+from ebookmaker.CommonCode import filesdir, Options, EbookmakerBadFileException
 from ebookmaker.utils import add_class, add_style, css_len, replace_elements, xpath
 from . import HTMLParserBase
 from .boilerplate import mark_soup
@@ -500,7 +500,10 @@ class Parser(HTMLParserBase):
                 if not infigure:
                     warning(NO_ALT_TEXT, elem.get('src'))
             id_ = elem.get('id')
-            info(f'[ALTTEXT]{self.attribs.url},{id_},{alt},{elem.get("src")},{infigure}')
+            rel_url = make_url_relative(parsers.webify_url(filesdir()), self.attribs.url)
+            src_rel_url = make_url_relative(self.attribs.url, elem.get("src"))
+            alt = alt.replace('"','""').replace("'","''")
+            info(f'[ALTTEXT]{rel_url},{id_},"{alt}",{src_rel_url},{infigure}')
                 
 
         ##### cleanup #######

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -478,14 +478,14 @@ class Parser(HTMLParserBase):
                     figure.attrib['aria-labelledby'] = caption.attrib['id']
                     break
         
-        # process alt tags
-        # work around bug in w3c validator: 
+        # process img tags
         for elem in xpath(self.xhtml, "//xhtml:img"):
             id_ = elem.get('id')
             if self.alter.get(id_) != None:  # it's None if there is no json file
                 alt = self.alter.get(id_)
                 elem.attrib['alt'] = alt
                 continue
+
             infigure = False
             labeled = elem.get('aria-labelledby')
             if labeled and labeled in self.seen_ids:
@@ -514,7 +514,6 @@ class Parser(HTMLParserBase):
 
             rel_url = make_url_relative(parsers.webify_url(filesdir()), self.attribs.url)
             src_rel_url = make_url_relative(self.attribs.url, elem.get("src"))
-            alt = alt.replace('"','""').replace("'","''")
             info(f'[ALTTEXT]{csv_escape([rel_url, id_, alt, src_rel_url, infigure])}')
                 
 

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -28,7 +28,7 @@ from libgutenberg.Logger import critical, info, debug, warning, error
 from libgutenberg.MediaTypes import mediatypes as mt
 
 from ebookmaker import parsers
-from ebookmaker.CommonCode import (EbookAltText, EbookmakerBadFileException,
+from ebookmaker.CommonCode import (csv_escape, EbookAltText, EbookmakerBadFileException,
                                    filesdir, Options, pgnum_from_url)
 from ebookmaker.utils import add_class, add_style, css_len, replace_elements, xpath
 from . import HTMLParserBase
@@ -514,7 +514,7 @@ class Parser(HTMLParserBase):
             rel_url = make_url_relative(parsers.webify_url(filesdir()), self.attribs.url)
             src_rel_url = make_url_relative(self.attribs.url, elem.get("src"))
             alt = alt.replace('"','""').replace("'","''")
-            info(f'[ALTTEXT]{rel_url},{id_},"{alt}",{src_rel_url},{infigure}')
+            info(f'[ALTTEXT]{csv_escape([rel_url, id_, alt, src_rel_url, infigure])}')
                 
 
         ##### cleanup #######

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -157,7 +157,7 @@ INAPPROPRIATE_ALTTEXT = {
 }
 
 DECORATIVE_ALTTEXT = {
-    "decoration", "decorative line", "(decorative)", "decoration", "décoration",
+    "decoration", "decorative line", "(decorative)", "décoration",
     "ilustración de adorno", "dekoration", "divider", "ornamental line", "adorno", "ornament.",
     "page deco", "decorative image", "[decorative image unavailable.]", "decorative header",
     "adorno fin de capítulo", "ornament",

--- a/src/ebookmaker/utils.py
+++ b/src/ebookmaker/utils.py
@@ -37,7 +37,8 @@ def add_style(elem, style=''):
         elem.set('style', style)
 
 def check_lang(elem, lang_att):
-    three2two = {'ita': 'it', 'lat': 'la', 'heb': 'he', 'fra': 'fr', 'spa': 'es', 'deu': 'de'}
+    three2two = {'ita': 'it', 'lat': 'la', 'heb': 'he', 'fra': 'fr', 'spa': 'es', 'deu': 'de',
+                 'gla': 'gd', 'oji': 'oj', 'nav': 'nv',}
     lang_att = three2two.get(lang_att, lang_att)
     lang = elem.attrib[lang_att]
     lang_name = gg.language_map.get(lang, default=None)

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -31,7 +31,7 @@ from libgutenberg.MediaTypes import mediatypes as mt
 from ebookmaker import parsers
 from ebookmaker import ParserFactory
 from ebookmaker import HTMLChunker
-from ebookmaker.CommonCode import Options
+from ebookmaker.CommonCode import EbookAltText, Options
 from ebookmaker.Version import VERSION, GENERATOR
 
 from .EpubWriter import (
@@ -113,9 +113,7 @@ body.x-ebookmaker-coverpage {
 """
 
 def alt_text_good(book_id):
-    # stub implementation which allows listing books with good alt text in config file
-    return str(book_id) in options.good_alt_text.split() if hasattr(
-        options, 'good_alt_text') else False
+    return EbookAltText(book_id).get('x') != None
 
 
 class OEBPSContainer(EpubWriter.OEBPSContainer):

--- a/src/ebookmaker/writers/Epub3Writer.py
+++ b/src/ebookmaker/writers/Epub3Writer.py
@@ -551,6 +551,11 @@ class Writer(EpubWriter.Writer):
                     del e.attrib[key]
                     new_key = getattr(NS.epub, key[10:])
                     e.attrib[new_key] = val
+        # other end of work-around for validator bug
+        for e in xpath(xhtml, "//xhtml:img[@data-role]"):
+            role = e.attrib['data-role']
+            e.attrib['role'] = role
+            del e.attrib['data-role']
 
     @staticmethod
     def fix_incompatible_css(sheet):

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -1054,7 +1054,7 @@ class Writer(writers.HTMLishWriter):
                 writers.HTMLWriter.add_class(tag, newtag)
 
         # replace html5 inline tags
-        for newtag in ['u']:
+        for newtag in ['u', 'ruby', 'rt', 'rp']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):
                 usedtags.add(newtag)
                 tag.tag = NS.xhtml.span

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -1040,7 +1040,7 @@ class Writer(writers.HTMLishWriter):
                 elem.set(attr, fill)
 
         # remove html5-only attribute
-        attrs_to_remove = [('*', 'role'),('*', 'aria-label'),('*', 'aria-labelledby'),]
+        attrs_to_remove = [('*', 'role'),]
         for (tag, attr) in attrs_to_remove:
             for elem in xpath(xhtml, f"//xhtml:{tag}[@{attr}]"):
                 del elem.attrib[attr]
@@ -1133,6 +1133,16 @@ class Writer(writers.HTMLishWriter):
             for key in e.attrib.keys():
                 if key.startswith('data-'):
                     del e.attrib[key]
+
+    @staticmethod
+    def strip_aria_attribs(xhtml):
+        """ Epubcheck doesn't like data- attributes in EPUB2.
+        """
+        for e in xpath(xhtml, "//@*[starts-with(name(), 'aria')]/.."):
+            for key in e.attrib.keys():
+                if key.startswith('aria-'):
+                    del e.attrib[key]
+
 
 
     @staticmethod
@@ -1403,6 +1413,7 @@ class Writer(writers.HTMLishWriter):
                         p.strip_links(xhtml, job.spider.dict_urls_mediatypes())
                         self.strip_links(xhtml, job.spider.dict_urls_mediatypes())
                         self.strip_data_attribs(xhtml)
+                        self.strip_aria_attribs(xhtml)
 
                         self.strip_noepub(xhtml)
                         # self.strip_rst_dropcaps(xhtml)

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -1361,6 +1361,10 @@ class Writer(writers.HTMLishWriter):
                     else:
                         # make a copy so we can mess around
                         p.parse()
+
+                        # rewrite the changed image links
+                        p.remap_links(idmap)
+
                         xhtml = copy.deepcopy(p.xhtml) if hasattr(p, 'xhtml') else None
                     if xhtml is not None:
                         if not boilerplate_done:

--- a/tests/files/43172/43172-h/43172-h.htm
+++ b/tests/files/43172/43172-h/43172-h.htm
@@ -145,6 +145,9 @@ Giuseppe Chiarini, Giovanni Pascoli, Adolfo Venturi, Enrico Panzacchi.
 1897.
 </p>
 </div>
+<img src="images/image.jpg" id="testimage2" alt="" />
+<img src="images/image.jpg" id="testimage3" alt="[Image unavailable.]" />
+<img src="images/image.jpg" id="testimage4" alt="Décoration" />
 
 <div class="verso">
 <hr class="mid" />

--- a/tests/files/43172/43172-h/43172-h.htm
+++ b/tests/files/43172/43172-h/43172-h.htm
@@ -121,7 +121,7 @@ generously made available by The Internet Archive)
 <span class="small">DURANTE LA</span><br /><br />
 <span class="x-large">Rivoluzione francese e l'Impero</span>
 </p>
-
+<img src="images/image.jpg" id="testimage" alt="" />
 <hr class="tiny pad2" />
 
 <p class="pad4 large">

--- a/tests/files/43172/43172-h/43172-nocover.htm
+++ b/tests/files/43172/43172-h/43172-nocover.htm
@@ -184,7 +184,7 @@ I.
 <br />
 <span class="smcap">Rivoluzione e Misoneismo.</span>
 </h2>
-
+<img src="images/image.jpg" id="testimage" alt="" />
 <p>
 Quella che si suole chiamare Rivoluzione dell'89,
 non fu che una grande rivolta e un grande

--- a/tests/test_htm.py
+++ b/tests/test_htm.py
@@ -32,8 +32,6 @@ class TestFromHtm(unittest.TestCase):
         for out in outs:
             self.assertTrue(os.path.exists(os.path.join(self.out_dir, out % book_id)))
             os.remove(os.path.join(self.out_dir, out % book_id))
-        os.remove(os.path.join(self.out_dir, 'images/image.jpg'))              
-        os.rmdir(os.path.join(self.out_dir, 'images'))              
 
     def test_43172_nocover(self):
         book_id = '43172'
@@ -58,5 +56,5 @@ class TestFromHtm(unittest.TestCase):
         for out in outs:
             self.assertTrue(os.path.exists(os.path.join(self.out_dir, out % book_id)))
             os.remove(os.path.join(self.out_dir, out % book_id))
-            
-        
+        os.remove(os.path.join(self.out_dir, 'images/image.jpg'))              
+        os.rmdir(os.path.join(self.out_dir, 'images'))              

--- a/tests/test_htm.py
+++ b/tests/test_htm.py
@@ -16,7 +16,7 @@ class TestFromHtm(unittest.TestCase):
         book_id = '43172'
         dir = os.path.join(self.sample_dir, book_id)
         htmfile = os.path.join(dir, '%s-h' % book_id, '%s-h.htm' % book_id)
-        cmd = f'ebookmaker --ebook=43172 --make=test --output-dir={self.out_dir} '
+        cmd = f'ebookmaker -v --ebook=43172 --make=test --output-dir={self.out_dir} '
         cmd += f'--validate {htmfile}'
 
         output = subprocess.check_output(cmd, shell=True)


### PR DESCRIPTION
0.12.48 December 30, 2024
- the existing warnings for empty alt attributes proved to be somewhat counterproductive. The physician's motto "first, do no harm" is wise. Empty alt attributes are in many cases the correct solution for accessibility, but there are many commonly used entries that are much worse for accessibility. Based on a census of actual alt text entries, the following changes are being made:
    - empty WARNING  for empty strings in alt attributes is changed to an INFO message. (total 179,161 occurrences)
    - common decorative image indicators in alt text (such as "decoration") are now removed from alt text with a WARNING and data-role="presentation" is added. (total 6,288 occurrences)
    - common inappropriate alt text entries (such as "[image unavailable.]") are now replaced with "" and an ERROR message. (total 16420 occurrences). fixes #239
    - improved alt-text logging, refactored filesdir
- fixed a very old bug that affects only EPUB2 files generated from html that references GIF files in CSS. It's long been the case that Ebookmaker converts gif files to png for EPUB packaging, and this bug was fixed for EPUB3 files when EPUB3 support was added.
- added experimental alt-text insertion capability in HTMLParser. It checks for a json file of contributed alt text in the logs directory. Added some code to test that it works. Implemented the alt_text_good method to update the EPUB3 accessibility data.
- added gd, nv, and oj to the 3 to 2 language table, fixing #243
- added removal for aria-* and role attributes for EPUB2 files.
- restore role attribute from data-role attributes for EPUB3 files since the EPUB validator doesn't have the html5 validator's bug.
- (via libgutenberg) fixed bug that caused original publication year to be omitted for pubinfo strings. Fixes #245
- replace ruby markup for EPUB2, rb element for HTML5. (`ruby`, `rt` and `rp` are not allowed in EPUB2, and `rb`, "ruby base", is deprecated in HTML5) Fixes #244.
