### PR TITLE
0.13.6 misc bugfixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.13.5 WIP
 - completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
 - the error log messages for txt files missing header or footer markers now issue from the parser.
+- fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
 
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 0.13.5 WIP
 - completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
-- the error log messages for txt files missing header or footer markers now issue from the parser.
+- the error log messages for txt files missing header or footer markers now issue from the parser. Fixes #259.
 - fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
+- when audio file links are replaced with audio elements, the link contents is now kept in a span tag containing the audio element. Fixes #260
 
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,12 @@
-0.13.5 March 5, 2025
+0.13.6 March 6, 2025
 - completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
 - the error log messages for txt files missing header or footer markers now issue from the parser. 
 - fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
 - when audio file links are replaced with audio elements, the link contents is now kept in a span tag containing the audio element. Fixes #260
 - when there is no release date, we no longer report "January 01, 0001". Fixes #261.
-- Logger.ebook is now set before the first parse, so that we can better trace encoding problems
+- `ebook` is now an instance attribute of the `job` object. It was persisting across instantiations, which is not desired.
+- Logger.ebook is now set before the first parse, so that we can better trace encoding problems.
+- The file url is now reported when logging encoding errors.
 
 
 0.13.4 January 22, 2025

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,11 @@
-0.13.5 WIP
+0.13.5 March 5, 2025
 - completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
-- the error log messages for txt files missing header or footer markers now issue from the parser. Fixes #259.
+- the error log messages for txt files missing header or footer markers now issue from the parser. 
 - fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
 - when audio file links are replaced with audio elements, the link contents is now kept in a span tag containing the audio element. Fixes #260
 - when there is no release date, we no longer report "January 01, 0001". Fixes #261.
+- Logger.ebook is now set before the first parse, so that we can better trace encoding problems
+
 
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 0.13.5 WIP
 - completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
+- the error log messages for txt files missing header or footer markers now issue from the parser.
+
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - the error log messages for txt files missing header or footer markers now issue from the parser. Fixes #259.
 - fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
 - when audio file links are replaced with audio elements, the link contents is now kept in a span tag containing the audio element. Fixes #260
+- when there is no release date, we no longer report "January 01, 0001". Fixes #261.
 
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+0.13.5 WIP
+- completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
 0.13.4 January 22, 2025
 - fix failed parsing when an `a` element has no tail
 

--- a/ebookmaker.conf
+++ b/ebookmaker.conf
@@ -12,7 +12,6 @@
 # exclude_urls: [list]
 # include_mediatypes: [list of mediatypes]
 # exclude_mediatypes: [list of mediatypes]
-# input_mediatype: None
 # mediatype_from_extension: False
 # rewrite: [url]>[rewritten url]
 # title: None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = ebookmaker
 
-version = 0.13.5
+version = 0.13.6
 
 [options]
 package_dir=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = ebookmaker
 
-version = 0.13.4
+version = 0.13.5
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.13.4'
+VERSION = '0.13.5'
 
 if __name__ == "__main__":
  

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.13.5'
+VERSION = '0.13.6'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/CommonCode.py
+++ b/src/ebookmaker/CommonCode.py
@@ -54,6 +54,7 @@ class Job(object):
         self.opf_identifier = None
         self.main = None
         self.link_map = {}
+        self.job = 0
 
 
     def __str__(self):

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -481,7 +481,8 @@ def do_job(job):
 
 
             if options.input_mediatype:
-                attribs.orig_mediatype = options.input_mediatype
+                info('the --input-mediatype option is ignored and will be removed')
+                #attribs.orig_mediatype = options.input_mediatype
 
             spider.recursive_parse(attribs)
             if job.type.split('.')[0] in ('epub', 'epub3', 'html', 'kindle', 'cover', 'pdf'):

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -587,7 +587,7 @@ def main():
     for job in job_queue:
         try:
             debug('Job starting for type %s from %s', job.type, job.url)
-            Logger.ebook = job.ebook if hasattr(job, 'ebook') else 0
+            Logger.ebook = job.ebook
             dc = get_dc(job) # this is when doc at job.url gets parsed!
             job.dc = dc
             job.last_updated()

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -587,6 +587,7 @@ def main():
     for job in job_queue:
         try:
             debug('Job starting for type %s from %s', job.type, job.url)
+            Logger.ebook = job.ebook if hasattr(job, 'ebook') else 0
             dc = get_dc(job) # this is when doc at job.url gets parsed!
             job.dc = dc
             job.last_updated()

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.13.5'
+VERSION = '0.13.6'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.13.4'
+VERSION = '0.13.5'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/GutenbergTextParser.py
+++ b/src/ebookmaker/parsers/GutenbergTextParser.py
@@ -23,7 +23,7 @@ from pkg_resources import resource_string
 
 import libgutenberg.GutenbergGlobals as gg
 from libgutenberg.GutenbergGlobals import xpath, Struct, NS
-from libgutenberg.Logger import warning, info, debug
+from libgutenberg.Logger import debug, error, info, warning
 from libgutenberg.MediaTypes import mediatypes as mt
 
 from ebookmaker import parsers

--- a/src/ebookmaker/parsers/GutenbergTextParser.py
+++ b/src/ebookmaker/parsers/GutenbergTextParser.py
@@ -627,6 +627,11 @@ class Parser(HTMLParserBase):
 
         text = self.unicode_content()
         text, pg_header, pg_footer = strip_headers_from_txt(text)
+        if 'x-header' in pg_header and options.production:
+            error('header marker is missing in %s', self.attribs.url)
+        if 'x-header' in pg_footer and options.production:
+            error('footer marker is missing in %s', self.attribs.url)
+
         text = parsers.RE_RESTRICTED.sub('', text)
         text = gg.xmlspecialchars(text)
 

--- a/src/ebookmaker/parsers/HTMLParser.py
+++ b/src/ebookmaker/parsers/HTMLParser.py
@@ -234,6 +234,8 @@ class Parser(HTMLParserBase):
                 id_ = bytes_id.decode('utf-8')
             except UnicodeError:
                 pass # too broken to fix
+            except AttributeError:
+                error(f'bad encoding: id_: {id_}, bytes_id: {bytes_id}')
 
         id_ = RE_NOT_XML_NAMECHAR.sub('_', id_)
         # An xml:id cannot start with a digit, a very common mistake
@@ -246,7 +248,7 @@ class Parser(HTMLParserBase):
             # still invalid ... we tried
             return None
 
-        # debug("_fix_internal_frag: frag = %s" % id_)
+        #debug(f"_fix_internal_frag: {id_}")
         return id_
 
 

--- a/src/ebookmaker/parsers/__init__.py
+++ b/src/ebookmaker/parsers/__init__.py
@@ -322,7 +322,7 @@ class ParserBase(object):
             error("Invalid charset name: %s (%s)" % (charset, what))
         except UnicodeError as what:
             # mis-stated charset, did not decode
-            error("Text not in charset %s (%s)" % (charset, what))
+            error(f"Text in {self.attribs.url} not in charset {charset} ({what})")
         return None
 
 

--- a/src/ebookmaker/parsers/boilerplate.py
+++ b/src/ebookmaker/parsers/boilerplate.py
@@ -161,8 +161,8 @@ def strip_headers_from_txt(text):
         return  text, None, text
     header_text, divider, text = markers_split(text, TOP_MARKERS + SMALLPRINT_MARKERS)
     if divider is None:
-        pg_header = '<pre id="pg-header"></pre>'
-        info('No PG header found. This is an ERROR for white-washed files.')
+        pg_header = '<pre id="pg-header" x-header="0"></pre>'
+        info('No PG header found in txt file.')
 
     else:
         divider_tail = ''
@@ -177,8 +177,8 @@ def strip_headers_from_txt(text):
 
     text, divider, footer_text = markers_split(text, BOTTOM_MARKERS)
     if divider is None:
-        pg_footer = '<pre id="pg-footer"></pre>'
-        info('No PG footer found. This is an ERROR for white-washed files.')
+        pg_footer = '<pre id="pg-footer" x-footer="0"></pre>'
+        info('No PG footer found in txt file.')
     else:
         pg_footer = '\n'.join(['<pre id="pg-footer">',
                                divider,

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -64,6 +64,10 @@ def pgheader(dc):
         updated = ''
     else:
         updated = f'{nl}{padding}Most recently updated: {dc.update_date.strftime(hr_format)}'
+    if dc.release_date == datetime.date.min:
+        release_date = 'No release date'
+    else:
+        release_date = dc.release_date.strftime(hr_format)
     pg_header = '<section class="pg-boilerplate pgheader" id="pg-header" xml:lang="en" lang="en" xmlns="http://www.w3.org/1999/xhtml">'
     pg_header += "<h2 id='pg-header-heading' title=''>"
     pg_header += 'The Project Gutenberg eBook of '
@@ -78,7 +82,7 @@ def pgheader(dc):
         dcauthlist(dc)
     }</div>
 {pstyle('Release Date', 
-            f'{dc.release_date.strftime(hr_format)} [eBook #{dc.project_gutenberg_id}]' + updated)}
+            f'{release_date} [eBook #{dc.project_gutenberg_id}]' + updated)}
 {pstyle('Language', ', '.join(language_list))}
 {pstyle('Original Publication', str(dc.pubinfo))}
 {pstyle('Credits', dc.credit)}

--- a/src/ebookmaker/writers/PDFWriter.py
+++ b/src/ebookmaker/writers/PDFWriter.py
@@ -38,6 +38,7 @@ class Writer (writers.BaseWriter):
         debug ("Creating PDF file: %s" % outputfilename)
 
         mkdir_for_filename(outputfilename)
+        debug(f'parser input is {inputfilename}')
         parser = ParserFactory.ParserFactory.create (inputfilename)
 
         if not hasattr (parser, 'rst2xetex'):


### PR DESCRIPTION
- completely ignored `input_mediatype`; and added deprecation notice. will remove --input-mediatype in the future. Because we started using cchardet, ebookmaker is much better at determining document encoding than are humans, so we started mostly ignoring declared encodings. But Online Ebookmaker has asked users to declare encoding, which confused v0.13.
- the error log messages for txt files missing header or footer markers now issue from the parser. 
- fixed a bug triggered by urlencoded spaces in an id fragment - seen in #48368
- when audio file links are replaced with audio elements, the link contents is now kept in a span tag containing the audio element. Fixes #260
- when there is no release date, we no longer report "January 01, 0001". Fixes #261.
- Logger.ebook is now set before the first parse, so that we can better trace encoding problems. Fixes #259.