### PR TITLE
Include format output filename in the log

### DIFF
--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -517,7 +517,8 @@ def do_job(job):
         exception(f"{job.type} raises exception {what}")
 
     end_time = datetime.datetime.now()
-    info(' %s made in %s' % (job.type, end_time - start_time))
+    info('%s output in %s' % (job.type, job.outputfile))
+    info('%s completed in %s' % (job.type, end_time - start_time))
 
     if log_handler:
         close_log(log_handler)

--- a/src/ebookmaker/EbookMaker.py
+++ b/src/ebookmaker/EbookMaker.py
@@ -383,7 +383,7 @@ def add_local_options(ap):
         metavar="CONFIG_DIR",
         dest="configdir",
         default="",
-        help="config directory (default: ''")
+        help="config directory (default: '')")
 
     ap.add_argument(
         "--output-file",


### PR DESCRIPTION
To programatically pair the ebookmaker generated artifacts with the requested formats on the command line, include the format's filename in the output log. This will ultimately help create a lightweight API in https://github.com/gutenbergtools/ebookmaker-web for use by https://github.com/DistributedProofreaders/guiguts-py/.

In an ideal world ebookmaker would allow generating a JSON file that would contain structured output for programmatic consumption, but this is an easy short-term hack.

_Disclaimer: this is untested code._