### PR TITLE
Update README with info on pkg_resources error

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Check your install:
 `$ ebookmaker --version`
 `EbookMaker 0.12.0`
 
+> Note: If you get an error similar to this one:
+>
+> `ModuleNotFoundError: No module named 'pkg_resources'`
+>
+> You can fix it by installing the `setuptools` module:
+>
+> `$ pipenv run pip install setuptools`
+
 Since you're in the shell, you can navigate to a book's directory and convert it:
 
 `$ ebookmaker -v -v --make=epub.images --ebook 10001 --title "The Luck of the Kid" --author "Ridgwell Cullum" luck-kid.html`

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Install pipenv  (might be `pip install --user pipenv`, depending on your default
 
 `$ pip3 install --user pipenv`
 
+(Debian/Ubuntu Linux users will instead need to use `apt install pipenv`.)
+
 The default install location is `${HOME}/.local/bin`, so add this to your login shell's ${PATH} if needed.
 
 Change directories to where you want to have your ebookmaker environment. Then, to initialize a python 3 virtual environment, do
@@ -92,13 +94,13 @@ Check your install:
 `$ ebookmaker --version`
 `EbookMaker 0.12.0`
 
-> Note: If you get an error similar to this one:
+> **If you get an error similar to this one:**
 >
 > `ModuleNotFoundError: No module named 'pkg_resources'`
 >
 > You can fix it by installing the `setuptools` module:
 >
-> `$ pipenv run pip install setuptools`
+> `$ pipenv install setuptools`
 
 Since you're in the shell, you can navigate to a book's directory and convert it:
 


### PR DESCRIPTION
Due to pkg_resources being deprecated and later removed from the default Python distribution (as of 3.12), users might get an exception due to pkg_resources not being installed.