### PR TITLE
0.13.8

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
-0.13.8 August ?, 2025
+0.13.8 August 7, 2025
 - to address kobo reader crash when a span containing multiple spaces has padded, moved txt padding spaces out of the span with padding. fixes #286
 - updated CSSParser for  https://www.w3.org/TR/css-writing-modes-3/ . fixes #285
     - `direction` and `unicode-bidi`  are not supported based on the standard's recommendationies a
-    - the following properties no longer are errors. Ebookmaker makes so attempt to fix these for EPUB2. This should allow better rendering in reading systems that support asian languages and bidirectional text, which are most modern reading systems.
+    - the following properties are no longer errors. Ebookmaker makes no attempt to modify these for EPUB2. This should allow better rendering in reading systems that support asian languages and bidirectional text, which are most modern reading systems.
         - `writing-mode`
         - `text-orientation`
         - `text-combine-upright`

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 0.13.8 August ?, 2025
-- to address kobo reader crash when a span containing multiple spaces has padded, moved txt padding spaces out of the span with padding
+- to address kobo reader crash when a span containing multiple spaces has padded, moved txt padding spaces out of the span with padding. fixes #286
+- updated CSSParser for  https://www.w3.org/TR/css-writing-modes-3/ . fixes #285
+    - `direction` and `unicode-bidi`  are not supported based on the standard's recommendationies a
+    - the following properties no longer are errors. Ebookmaker makes so attempt to fix these for EPUB2. This should allow better rendering in reading systems that support asian languages and bidirectional text, which are most modern reading systems.
+        - `writing-mode`
+        - `text-orientation`
+        - `text-combine-upright`
 
 0.13.7 May 21, 2025
 - fixed typo in add_local_options, added a log message to report outputfile location (thanks @cpeel)

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.13.8 August ?, 2025
+- to address kobo reader crash when a span containing multiple spaces has padded, moved txt padding spaces out of the span with padding
+
 0.13.7 May 21, 2025
 - fixed typo in add_local_options, added a log message to report outputfile location (thanks @cpeel)
 - removed the online ebookmaker script, now at https://github.com/gutenbergtools/ebookmaker-web/ from (@Rossolson)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = ebookmaker
 
-version = 0.13.7
+version = 0.13.8
 
 [options]
 package_dir=

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup
 
-VERSION = '0.13.7'
+VERSION = '0.13.8'
 
 if __name__ == "__main__":
  

--- a/src/ebookmaker/Version.py
+++ b/src/ebookmaker/Version.py
@@ -1,2 +1,2 @@
-VERSION = '0.13.7'
+VERSION = '0.13.8'
 GENERATOR = 'Ebookmaker %s by Project Gutenberg'

--- a/src/ebookmaker/parsers/CSSParser.py
+++ b/src/ebookmaker/parsers/CSSParser.py
@@ -61,6 +61,12 @@ PG_CSS_PROFILE = (
         'text-decoration': 'initial',
         'text-indent': 'initial',
         'text-transform': 'initial',
+        
+        # updated for  https://www.w3.org/TR/css-writing-modes-3/
+        # direction and unicode-bidi  are not supported based on the standard's recommendation
+        'writing-mode': 'vertical-lr|vertical-rl|horizontal-tb',
+        'text-orientation': 'mixed|upright|sideways',
+        'text-combine-upright': 'none | all',      
     },
     {
         'numeric-figure-values': 'lining-nums|oldstyle-nums',

--- a/src/ebookmaker/writers/HtmlTemplates.py
+++ b/src/ebookmaker/writers/HtmlTemplates.py
@@ -31,7 +31,8 @@ def pgheader(dc):
             return ''
         val = f'<br/>\n{padding}'.join([html.escape(v) for v in val.split('\n')])
         if key == 'Previous':
-            return f'''<p style='margin-top:0'><span style='padding-left: 7.5ex'>{padding}</span>{val}</p>{nl}'''
+            # note: having the padding inside the span was causing kobo readers to crash
+            return f'''<p style='margin-top:0'>{padding}<span style='padding-left: 7.5ex'></span>{val}</p>{nl}'''
         else:
             return f'''<p><strong>{key}</strong>: {val}</p>{nl}'''
 


### PR DESCRIPTION
2 simple fixes

0.13.8 August 7, 2025
- to address kobo reader crash when a span containing multiple spaces has padded, moved txt padding spaces out of the span with padding. fixes #286
- updated CSSParser for  https://www.w3.org/TR/css-writing-modes-3/ . fixes #285
    - `direction` and `unicode-bidi`  are not supported based on the standard's recommendationies a
    - the following properties are no longer errors. Ebookmaker makes no attempt to modify these for EPUB2. This should allow better rendering in reading systems that support asian languages and bidirectional text, which are most modern reading systems.
        - `writing-mode`
        - `text-orientation`
        - `text-combine-upright`
