### PR TITLE
Add `html` resource min width extractor

### DIFF
--- a/src/ebookmaker/writers/PDFWriter.py
+++ b/src/ebookmaker/writers/PDFWriter.py
@@ -26,6 +26,7 @@ from ebookmaker.CommonCode import Options
 options = Options()
 
 PDFCSS = os.path.join(os.path.dirname(__file__), 'pdf.css')
+PAGEDJSCLI_HOOKS_HANDLER_PATH = './pagedjs_hooks.js'
 
 class Writer(writers.BaseWriter):
     """ Class to write PDF. """
@@ -52,6 +53,7 @@ class Writer(writers.BaseWriter):
                         job.url,
                         '--style', PDFCSS,
                         '-o', outputfilename,
+                        '--additional-script', PAGEDJSCLI_HOOKS_HANDLER_PATH
                     ],
                     capture_output=True
                 )

--- a/src/ebookmaker/writers/pagedjs_hooks.js
+++ b/src/ebookmaker/writers/pagedjs_hooks.js
@@ -1,0 +1,53 @@
+isDebug = false;
+
+/**	getPagedMinimumWidth(pageElement)
+ * @param {*} pageElement - an HTML element
+ * @returns {number} the minimum page width
+ */
+function getPageMinimumWidth(pageElement) {
+	// Custom requested [injected script](https://github.com/gutenbergtools/ebookmaker/issues/289#issuecomment-3249911801)
+	return Math.max(
+		pageElement.scrollWidth,
+		pageElement.offsetWidth,
+		pageElement.clientWidth,
+		// assuming that `document` refers to `page_element`; then this following code is assumed:
+		pageElement.documentElement.scrollWidth,
+		pageElement.documentElement.offsetWidth,
+		pageElement.documentElement.clientWidth
+	);
+}
+
+// Follows Documentation Example: https://pagedjs.org/en/documentation/10-handlers-hooks-and-custom-javascript/
+class PG_PagedJS_Hook_Handler extends Paged.Handler {
+	constructor(chunker, polisher, caller) {
+		super(chunker, polisher, caller);
+	}
+
+	afterRendered(pages) {
+		// console.log(`pagedjs_hooks.js::pagedjs::afterRendered()::total page count: ${pages.length}`);
+
+		// if you want global minimum page width
+		let minimumWidth = 0;
+		pages.forEach((page) => {
+			pageElement = page.element;
+
+			minimumWidth = max(minimumWidth, getPageMinimumWidth(pageElement));
+
+			if(isDebug) {
+				console.log(`pagedjs_hooks.js::pagedjs::afterRendered()::current page minimum width: ${minimumWidth}`);
+			}
+		});
+
+		/*
+		// if you want to just sample a random/first page (assuming that there is at least one page)
+		const random_page_number = Math.floor(Math.random() * pages.length);
+		const sample_page = pages[random_page_number]; // replace `random_page_number` w/ `0` if only first page
+		const minimum_width = get_page_minimum_width(sample_page);
+		*/
+
+		console.log(`pagedjs_hooks.js::pagedjs::afterRendered()::global page minimum width: ${minimumWidth}`);
+	}
+}
+
+// Note: [var Paged = /*#__PURE__*/Object.freeze(...](https://unpkg.com/pagedjs@0.4.3/dist/paged.polyfill.js) reserves `Paged` as a global var
+Paged.registerHandlers(PG_PagedJS_Hook_Handler);


### PR DESCRIPTION
Added resource's minimum width extractor using `pagedjs` hooks. [intended to resolve this feature request](https://github.com/gutenbergtools/ebookmaker/issues/289#issuecomment-3249911801). need to test.