### PR TITLE
handle bock tags in `a`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 
-- `a` tags can't contain block tags in xhtml, so div in `a` and `p` in `a` cause EPUB2 validation errors, so Ebookmaker now changes `p` and `div` to `span` for EPUB2. I'm not sure why anyone would want to use this markup in a book. Fixes #333
+- `a` tags can't contain block tags in xhtml, so div in `a` and `p` in `a` cause EPUB2 validation errors, so Ebookmaker now changes `p` and `div` occurring in `a` to `span` for EPUB2. I'm not sure why anyone would want to use this markup in a book. Fixes #333
 
 0.14.2 July 4, 2026
 - `text-decoration` for `a` should be reset to `underline`, not initial. Fixes #316.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+
+- `a` tags can't contain block tags in xhtml, so div in `a` and `p` in `a` cause EPUB2 validation errors, so Ebookmaker now changes `p` and `div` to `span` for EPUB2. I'm not sure why anyone would want to use this markup in a book. Fixes #333
+
 0.14.2 July 4, 2026
 - `text-decoration` for `a` should be reset to `underline`, not initial. Fixes #316.
 

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -1083,6 +1083,14 @@ class Writer(writers.HTMLishWriter):
                 tag.tag = NS.xhtml.div
                 writers.HTMLWriter.add_class(tag, newtag)
 
+        # replace html5 block tags in forbidden contexts
+        for badblock in [('a', 'p'), ('a', 'div')]:
+            tag, blocktag = badblock
+            for block in xpath(xhtml, f'//xhtml:{tag}/xhtml:{blocktag}'):
+                usedtags.add(block)
+                block.tag = NS.xhtml.span
+                writers.HTMLWriter.add_class(block, f'{tag}_{blocktag}')
+
         # replace html5 inline tags
         for newtag in ['u', 'ruby', 'rt', 'rp']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):


### PR DESCRIPTION
`a` tags can't contain block tags in xhtml, so div in `a` and `p` in `a` cause EPUB2 validation errors, so Ebookmaker now changes `p` and `div` occurring in `a` to `span` for EPUB2. I'm not sure why anyone would want to use this markup in a book. fixes #333