### PR TITLE
underline links

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 
 0.14.3 August xx, 1996
+
+- In both in HTML and EPUB, for improved accessibility, added the css rule `a[href] {text-decoration: underline;}` to make sure links are underlined. Previously, we underlined all `a` elements, which ignored prior usage as an link target.
+
 - refactored boilerplate stripping for txt files so it only needs to be done once per book. boilerplate is now detected in the text Parser, instead of in the text Writer.
 - `a` tags can't contain block tags in xhtml, so div in `a` and `p` in `a` cause EPUB2 validation errors, so Ebookmaker now changes `p` and `div` occurring in `a` to `span` for EPUB2. I'm not sure why anyone would want to use this markup in a book. Fixes #333
 

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -110,6 +110,9 @@ span.u {
 a.pgkilled {
    text-decoration: none;
    }
+a[href] {
+    text-decoration: underline;
+}
 img.x-ebookmaker-cover {max-width: 100%;}
 #pg-header {page-break-after: always;}
 #pg-footer {page-break-before: always;}

--- a/src/ebookmaker/writers/HTMLWriter.py
+++ b/src/ebookmaker/writers/HTMLWriter.py
@@ -350,7 +350,7 @@ class Writer(writers.HTMLishWriter):
         # don't let the source change the body bgcolor or text color
         new_rule = css.CSSStyleRule(selectorText='body', style='background:initial;color:initial')
         sheet.add(new_rule)
-        new_rule = css.CSSStyleRule(selectorText='a', style='text-decoration:underline')
+        new_rule = css.CSSStyleRule(selectorText='a[href]', style='text-decoration:underline')
         sheet.add(new_rule)
 
     @staticmethod


### PR DESCRIPTION
- In both in HTML and EPUB, for improved accessibility, added the css rule `a[href] {text-decoration: underline;}` to make sure links are underlined. Previously, we underlined all `a` elements, which ignored prior usage as an link target. Fixes #329.