### PR TITLE
add aside

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 
 0.14.3 August ??, 2026
+
+- The `aside` element is now allowed. becomes div[class=aside] in epub2.
 - handling of inline SVG has been improved.
     - the inline SVG element is now handled whether or not it has set the svg namespace.
     - inline SVG is changed to standalone files in EPUB2

--- a/src/ebookmaker/writers/EpubWriter.py
+++ b/src/ebookmaker/writers/EpubWriter.py
@@ -1078,7 +1078,8 @@ class Writer(writers.HTMLishWriter):
 
         # replace html5 block tags
         usedtags = set()
-        for newtag in ['article', 'figcaption', 'figure', 'footer', 'header', 'section', 'nav', 'main']:
+        for newtag in ['article', 'figcaption', 'figure', 'footer', 'header', 'section', 'nav',
+                       'main', 'aside']:
             for tag in xpath(xhtml, f'//xhtml:{newtag}'):
                 usedtags.add(newtag)
                 tag.tag = NS.xhtml.div


### PR DESCRIPTION
The `aside` element is now allowed. becomes div[class=aside] in epub2. Addresses #321.